### PR TITLE
Backfill recently-online people's photos first

### DIFF
--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -947,8 +947,9 @@ CREATE INDEX IF NOT EXISTS idx__photo__uuid
     ON photo(uuid);
 
 -- The photocrop backfill's queue: tiny, and empties as the backlog drains.
-CREATE INDEX IF NOT EXISTS idx__photo__crop_backlog
-    ON photo(uuid)
+-- Covers the queue's join to `person`, whose `last_online_time` orders it.
+CREATE INDEX IF NOT EXISTS idx__photo__crop_backlog__person_id
+    ON photo(person_id, uuid)
     WHERE width IS NULL AND crop_attempted_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx__photo__nsfw_score

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -78,9 +78,13 @@ ALTER TABLE photo
     ADD COLUMN IF NOT EXISTS crop_attempted_at TIMESTAMP;
 
 -- The photocrop backfill's queue: tiny, and empties as the backlog drains.
-CREATE INDEX IF NOT EXISTS idx__photo__crop_backlog
-    ON photo(uuid)
+-- Covers the queue's join to `person`, whose `last_online_time` orders it;
+-- this replaced an earlier uuid-keyed index of the same shape.
+CREATE INDEX IF NOT EXISTS idx__photo__crop_backlog__person_id
+    ON photo(person_id, uuid)
     WHERE width IS NULL AND crop_attempted_at IS NULL;
+
+DROP INDEX IF EXISTS idx__photo__crop_backlog;
 
 -- The geometry JSON is now shaped in the application (`commonsql.PHOTO_GEOMETRY`)
 -- rather than by a database function; drop the function this migration used to

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -12,6 +12,7 @@ from service.cron.cronutil import (
     print_stacktrace,
 )
 from PIL import Image
+from datetime import datetime
 import asyncio
 import io
 import os
@@ -131,35 +132,44 @@ async def _backfill(uuids: list[str]) -> None:
         f'of {len(uuids)} photos'
     )
 
-async def backfill_photo_crops_once(after: str = '') -> str:
+Cursor = tuple[datetime, str]
+
+async def backfill_photo_crops_once(
+    after: Cursor | None = None,
+) -> Cursor | None:
     async with api_tx() as tx:
         cur = await tx.execute(
             Q_PHOTOS_WITHOUT_GEOMETRY,
-            dict(after=after, limit=PHOTO_CROP_BATCH_SIZE),
+            dict(
+                after_last_online=after[0] if after else None,
+                after_uuid=after[1] if after else None,
+                limit=PHOTO_CROP_BATCH_SIZE,
+            ),
         )
         rows = await cur.fetchall()
 
-    uuids = [row['uuid'] for row in rows]
-
-    if not uuids:
+    if not rows:
         return after
 
-    await _backfill(uuids)
+    await _backfill([row['uuid'] for row in rows])
 
-    return uuids[-1]
+    return (rows[-1]['last_online_time'], rows[-1]['uuid'])
 
 async def backfill_photo_crops_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
 
-    # The cursor only ever advances: a wet run drains the queue via
-    # `crop_attempted_at` anyway, and a dry run - which writes nothing - would
-    # otherwise re-download the same batch every poll. Restart to re-walk.
-    after = ''
+    # The cursor is only held between polls in a dry run - which writes nothing
+    # and would otherwise re-download the same batch every poll; restart to
+    # re-walk. A wet run drains the queue via `crop_attempted_at` and always
+    # takes the batch whose people were online most recently, so someone coming
+    # online mid-walk isn't skipped.
+    after: Cursor | None = None
 
     while True:
         async def advance() -> None:
             nonlocal after
-            after = await backfill_photo_crops_once(after)
+            cursor = await backfill_photo_crops_once(after)
+            after = cursor if DRY_RUN else None
 
         await print_stacktrace(advance)
         await asyncio.sleep(PHOTO_CROP_POLL_SECONDS)

--- a/backend/service/cron/photocrop/sql/__init__.py
+++ b/backend/service/cron/photocrop/sql/__init__.py
@@ -1,20 +1,33 @@
-# `crop_attempted_at` drains the queue: photos whose crop can't be recovered
-# would otherwise stay `width IS NULL` and be re-fetched on every pass. The
-# keyset cursor (`after`) does the same for dry runs, which never mark
-# anything. Served by the partial index idx__photo__crop_backlog.
+# Recently-online people first, so the photos most likely to be seen get their
+# geometry soonest. `crop_attempted_at` drains the queue: photos whose crop
+# can't be recovered would otherwise stay `width IS NULL` and be re-fetched on
+# every pass. The keyset cursor (`after_*`) does the same for dry runs, which
+# never mark anything. Served by the partial index
+# idx__photo__crop_backlog__person_id.
 Q_PHOTOS_WITHOUT_GEOMETRY = """
 SELECT
-    uuid
+    photo.uuid,
+    person.last_online_time
 FROM
     photo
+JOIN
+    person
+ON
+    person.id = photo.person_id
 WHERE
-    width IS NULL
+    photo.width IS NULL
 AND
-    crop_attempted_at IS NULL
-AND
-    uuid > %(after)s
+    photo.crop_attempted_at IS NULL
+AND (
+    %(after_uuid)s::TEXT IS NULL
+OR
+    (person.last_online_time, photo.uuid)
+    <
+    (%(after_last_online)s::TIMESTAMP, %(after_uuid)s::TEXT)
+)
 ORDER BY
-    uuid
+    person.last_online_time DESC,
+    photo.uuid DESC
 LIMIT
     %(limit)s
 """

--- a/backend/service/cron/photocrop/test_init.py
+++ b/backend/service/cron/photocrop/test_init.py
@@ -1,10 +1,14 @@
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 from unittest import mock
 import io
 import unittest
 
 import service.cron.photocrop as photocrop
 from duophoto.fixtures import jpeg, photo, renditions
+
+_SelectRow = dict[str, str | datetime]
+_SelectParams = dict[str, str | datetime | int | None]
 
 class TestGeometryOf(unittest.TestCase):
     def test_recovers_the_geometry_of_a_matching_pair(self) -> None:
@@ -165,6 +169,78 @@ class TestBackfill(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(tx.executed, [])
         self.assertEqual(tx.executed_many, [])
+
+class _FakeSelectCursor:
+    def __init__(self, rows: list[_SelectRow]) -> None:
+        self._rows = rows
+
+    async def fetchall(self) -> list[_SelectRow]:
+        return self._rows
+
+class _FakeSelectTx:
+    def __init__(self, rows: list[_SelectRow]) -> None:
+        self._rows = rows
+        self.params: list[_SelectParams | None] = []
+
+    async def execute(
+        self,
+        query: str,
+        params: _SelectParams | None = None,
+    ) -> _FakeSelectCursor:
+        self.params.append(params)
+        return _FakeSelectCursor(self._rows)
+
+class _FakeSelectApiTx:
+    def __init__(self, tx: _FakeSelectTx) -> None:
+        self._tx = tx
+
+    async def __aenter__(self) -> _FakeSelectTx:
+        return self._tx
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+class TestBackfillOnce(unittest.IsolatedAsyncioTestCase):
+    async def test_cursor_follows_the_last_row_and_feeds_the_next_poll(self) -> None:
+        rows: list[_SelectRow] = [
+            dict(uuid='a', last_online_time=datetime(2026, 7, 18, 12)),
+            dict(uuid='b', last_online_time=datetime(2026, 7, 1, 9)),
+        ]
+        tx = _FakeSelectTx(rows)
+        backfilled: list[list[str]] = []
+
+        async def fake_backfill(uuids: list[str]) -> None:
+            backfilled.append(uuids)
+
+        with mock.patch.object(photocrop, 'api_tx', lambda: _FakeSelectApiTx(tx)), \
+             mock.patch.object(photocrop, '_backfill', fake_backfill):
+            cursor = await photocrop.backfill_photo_crops_once()
+            await photocrop.backfill_photo_crops_once(cursor)
+
+        self.assertEqual(backfilled, [['a', 'b'], ['a', 'b']])
+        self.assertEqual(cursor, (datetime(2026, 7, 1, 9), 'b'))
+
+        first, second = tx.params
+        assert first is not None and second is not None
+        self.assertIsNone(first['after_uuid'])
+        self.assertIsNone(first['after_last_online'])
+        self.assertEqual(second['after_last_online'], datetime(2026, 7, 1, 9))
+        self.assertEqual(second['after_uuid'], 'b')
+
+    async def test_an_empty_queue_leaves_the_cursor_where_it_was(self) -> None:
+        tx = _FakeSelectTx([])
+        cursor = (datetime(2026, 7, 1, 9), 'b')
+        backfilled: list[list[str]] = []
+
+        async def fake_backfill(uuids: list[str]) -> None:
+            backfilled.append(uuids)
+
+        with mock.patch.object(photocrop, 'api_tx', lambda: _FakeSelectApiTx(tx)), \
+             mock.patch.object(photocrop, '_backfill', fake_backfill):
+            result = await photocrop.backfill_photo_crops_once(cursor)
+
+        self.assertEqual(result, cursor)
+        self.assertEqual(backfilled, [])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The backfill walks its queue in uuid order, which is arbitrary from a user's point of view: someone browsing today may look at profiles whose photos won't animate for days. This orders the queue by `person.last_online_time DESC`, so the profiles most likely to be seen get their geometry soonest, and someone who comes online mid-backfill jumps the queue on the next poll.

Mechanics:

- The queue query joins `person` and orders by `(last_online_time DESC, uuid DESC)`. The keyset cursor becomes a `(last_online_time, uuid)` pair; row-wise tuple comparison against that ordering is pinned by a read-only check against the DB.
- The cursor is now only held between polls in a **dry run** (its original purpose: not re-downloading the same batch every poll). A wet run always takes the current top of the queue — under a sort key that mutates as people come online, threading a cursor through a wet walk would skip exactly the people who should be prioritised. Wet runs still drain via `crop_attempted_at`, as before.
- `idx__photo__crop_backlog` is re-keyed as `idx__photo__crop_backlog__person_id ON photo(person_id, uuid)` (same `width IS NULL AND crop_attempted_at IS NULL` predicate), covering the join so each poll's scan of the remaining queue avoids heap fetches. The migration creates the new name and drops the old one, staying idempotent.

Each poll now scans and top-N sorts the whole remaining queue rather than resuming a keyset walk — that's inherent to a global priority order, and the cost shrinks as the backlog drains.

Tests: two new cases pin the cursor mechanics (it follows the last row and feeds the next poll's params; an empty queue leaves it unchanged). The photocrop suite needs the container's deps, so CI is the checkpoint — the `duophoto` tests and a syntax pass are green locally, and the query itself was executed read-only against a real schema.

Note for #1336 (backfiller removal): once this merges, that PR's `DROP INDEX` must also cover the new index name — updating it to drop both, which is safe under either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)