### PR TITLE
Move the "Get read receipts" upsell back above the message input

### DIFF
--- a/frontend/chat/application-layer/hooks/read-receipt.test.tsx
+++ b/frontend/chat/application-layer/hooks/read-receipt.test.tsx
@@ -6,6 +6,7 @@ jest.mock('../../websocket-layer', () => ({
 
 const PERSON = 'person-1';
 const READ_AT_KEY = `read-receipt-at-${PERSON}`;
+const OWN_LAST_MESSAGE_KEY = `conversation-own-last-message-at-${PERSON}`;
 
 const readReceiptDoc = (stamp?: string) => ({
   message: {
@@ -59,5 +60,65 @@ describe('read receipt resolution', () => {
     receive(readReceiptDoc());
 
     expect(readAt()).toBeNull();
+  });
+});
+
+describe('own last message tracking', () => {
+  let events: typeof import('../../../events/events');
+  let readReceipt: typeof import('./read-receipt');
+
+  const receive = (doc: unknown) => events.notify('chat-ws-receive', doc);
+
+  const ownLastMessageAt = (): Date | null =>
+    events.lastEvent<Date | null>(OWN_LAST_MESSAGE_KEY) ?? null;
+
+  const chatMessageDoc = (from: string = PERSON) => ({
+    message: {
+      '@type': 'chat',
+      '@from': `${from}@duolicious.app`,
+    },
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    events = require('../../../events/events');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    readReceipt = require('./read-receipt');
+  });
+
+  test('a published own last message is retained', () => {
+    const timestamp = new Date('2026-07-14T10:30:00.000Z');
+
+    readReceipt.notifyOwnLastMessageAt(PERSON, timestamp);
+
+    expect(ownLastMessageAt()).toEqual(timestamp);
+  });
+
+  test('an incoming chat message clears the own last message', () => {
+    readReceipt.notifyOwnLastMessageAt(
+      PERSON, new Date('2026-07-14T10:30:00.000Z'));
+
+    receive(chatMessageDoc());
+
+    expect(ownLastMessageAt()).toBeNull();
+  });
+
+  test('a chat message from another conversation leaves it alone', () => {
+    const timestamp = new Date('2026-07-14T10:30:00.000Z');
+    readReceipt.notifyOwnLastMessageAt(PERSON, timestamp);
+
+    receive(chatMessageDoc('person-2'));
+
+    expect(ownLastMessageAt()).toEqual(timestamp);
+  });
+
+  test('a read receipt leaves the own last message alone', () => {
+    const timestamp = new Date('2026-07-14T10:30:00.000Z');
+    readReceipt.notifyOwnLastMessageAt(PERSON, timestamp);
+
+    receive(readReceiptDoc('2026-07-14T11:00:00.000Z'));
+
+    expect(ownLastMessageAt()).toEqual(timestamp);
   });
 });

--- a/frontend/chat/application-layer/hooks/read-receipt.tsx
+++ b/frontend/chat/application-layer/hooks/read-receipt.tsx
@@ -4,7 +4,12 @@ import {
   notify,
   useDerivedEvent,
 } from '../../../events/events';
+import { useRetained } from '../../../events/use-retained';
 import { EV_CHAT_WS_RECEIVE } from '../../websocket-layer';
+import { useSignedInUser } from '../../../events/signed-in-user';
+
+const ownLastMessageEventKey = (personUuid: string) =>
+  `conversation-own-last-message-at-${personUuid}`;
 
 const readAtEventKey = (personUuid: string) =>
   `read-receipt-at-${personUuid}`;
@@ -17,6 +22,45 @@ const advanceReadAt = (personUuid: string, readTime: Date) => {
     notify<Date | null>(key, next);
   }
 };
+
+/**
+ * Publishes the timestamp of the conversation's last message, but only when the
+ * current user is the one who sent it (null otherwise — including when the other
+ * person's message is last). The chat controller drives this as messages are
+ * sent, received and fetched from the archive; the read-receipt model consumes
+ * it to decide whether to show the upsell for that message.
+ */
+const notifyOwnLastMessageAt = (
+  personUuid: string,
+  timestamp: Date | null,
+) => {
+  notify<Date | null>(ownLastMessageEventKey(personUuid), timestamp);
+};
+
+// A live message from the other person becomes the conversation's last message,
+// so our own message is no longer last and there's no receipt to sell: clear
+// it. Our own outgoing messages aren't echoed back on this stream (the
+// controller reports them from `sendMessage` instead), and the archived
+// history is reconciled whenever the conversation is fetched.
+const clearOwnLastMessageOnIncoming = (doc: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+  const message = doc?.message;
+
+  if (!message || message['@type'] !== 'chat') {
+    return;
+  }
+
+  const personUuid = String(message['@from'] ?? '').split('@')[0];
+
+  if (!personUuid) {
+    return;
+  }
+
+  if (lastEvent<Date | null>(ownLastMessageEventKey(personUuid)) != null) {
+    notifyOwnLastMessageAt(personUuid, null);
+  }
+};
+
+listen(EV_CHAT_WS_RECEIVE, clearOwnLastMessageOnIncoming);
 
 // A module-level listener (not a hook) so it's alive before the read-receipt UI
 // mounts: the read time arrives while the conversation is still loading from the
@@ -57,6 +101,22 @@ const useReadReceipt = (
     [deliveredAt?.getTime()],
   );
 
+/**
+ * Whether to offer the read-receipt upsell: the user can't see read receipts
+ * (they're not a gold user) but their message is the last one in the
+ * conversation, so there might be a receipt for it. The server never sends
+ * receipts to non-gold users, so `useReadReceipt` is always null for them —
+ * the two are mutually exclusive.
+ */
+const useReadReceiptUpsell = (personUuid: string): boolean => {
+  const [signedInUser] = useSignedInUser();
+  const ownLastMessageAt = useRetained<Date>(ownLastMessageEventKey(personUuid));
+
+  return !signedInUser?.hasGold && !!ownLastMessageAt;
+};
+
 export {
+  notifyOwnLastMessageAt,
   useReadReceipt,
+  useReadReceiptUpsell,
 };

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -12,6 +12,7 @@ import {
   EV_CHAT_WS_SEND_CLOSE,
   send,
 } from '../websocket-layer';
+import { notifyOwnLastMessageAt } from './hooks/read-receipt';
 import { ingestMamReaction } from './hooks/reaction';
 import {
   ingestCardAttributes,
@@ -704,6 +705,10 @@ const sendMessage = async (
 
     notify(`message-to-${recipientPersonUuid}`);
 
+    // Our message is now the conversation's last one, so a receipt for it can
+    // be shown once it's read.
+    notifyOwnLastMessageAt(recipientPersonUuid, timestamp);
+
     return {
       message: {
         type: 'chat-audio',
@@ -726,6 +731,10 @@ const sendMessage = async (
     setInboxSent(recipientPersonUuid, isGifUrl(text) ? GIF_MESSAGE : text);
 
     notify(`message-to-${recipientPersonUuid}`);
+
+    // Our message is now the conversation's last one, so a receipt for it can
+    // be shown once it's read.
+    notifyOwnLastMessageAt(recipientPersonUuid, timestamp);
 
     return {
       message: {
@@ -1088,6 +1097,17 @@ const fetchConversation = async (
   if (response !== 'timeout' && response.length > 0) {
     const lastMessage = response[response.length - 1];
     await markDisplayed(withPersonUuid, lastMessage.id, lastMessage.timestamp);
+  }
+
+  // Reconcile whether our message is the conversation's last one against the
+  // archive, but only on the first (most recent) page — older pages fetched
+  // while scrolling up don't change what's at the bottom.
+  if (response !== 'timeout' && beforeId === '') {
+    const lastMessage = response[response.length - 1];
+    notifyOwnLastMessageAt(
+      withPersonUuid,
+      lastMessage?.fromCurrentUser ? lastMessage.timestamp : null,
+    );
   }
 
   return response;

--- a/frontend/components/conversation-screen/conversation-screen.tsx
+++ b/frontend/components/conversation-screen/conversation-screen.tsx
@@ -27,6 +27,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { TopNavBar } from '../top-nav-bar';
 import { LogoActivityIndicator } from '../logo/logo-activity-indicator';
 import { ChatMessage, TypingIndicator } from './chat-message';
+import { ReadReceiptUpsell } from './read-receipt-upsell';
 import { DefaultText } from '../default-text';
 import {
   Message,
@@ -934,6 +935,7 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
           <View
             style={{
               flexDirection: 'row',
+              justifyContent: 'space-between',
               alignItems: 'flex-start',
             }}
           >
@@ -941,6 +943,7 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
               personUuid={personUuid}
               avatarUuid={photoUuid}
             />
+            <ReadReceiptUpsell personUuid={personUuid} />
           </View>
         </ScrollView>
       }

--- a/frontend/components/conversation-screen/message-receipt-logic.test.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.test.tsx
@@ -54,8 +54,8 @@ describe('receiptContent', () => {
       expect(kindOf({ side: 'status', hasGold: true })).toEqual('unread');
     });
 
-    test('a non-gold user is shown the upsell', () => {
-      expect(kindOf({ side: 'status' })).toEqual('upsell');
+    test('a non-gold user is shown a blank slot', () => {
+      expect(kindOf({ side: 'status' })).toEqual('blank');
     });
 
     test('the read time outranks the unread status', () => {
@@ -63,7 +63,7 @@ describe('receiptContent', () => {
         .toEqual('read');
     });
 
-    test('the read time outranks the upsell', () => {
+    test('the read time outranks the blank slot', () => {
       expect(kindOf({ side: 'status', readAt: READ_AT })).toEqual('read');
     });
   });
@@ -117,7 +117,6 @@ describe('contentKey', () => {
       contentKey({ kind: 'delivered', timestamp: DELIVERED_AT }),
       contentKey({ kind: 'read', timestamp: DELIVERED_AT }),
       contentKey({ kind: 'unread' }),
-      contentKey({ kind: 'upsell' }),
     ];
 
     expect(new Set(keys).size).toEqual(keys.length);
@@ -141,10 +140,6 @@ describe('contentText', () => {
 
   test('the unseen status is spelled out', () => {
     expect(contentText({ kind: 'unread' })).toEqual('Not seen yet');
-  });
-
-  test('the upsell keeps the name of the feature it sells', () => {
-    expect(contentText({ kind: 'upsell' })).toEqual('Get read receipts');
   });
 });
 

--- a/frontend/components/conversation-screen/message-receipt-logic.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.tsx
@@ -10,8 +10,7 @@ type Content =
   | { kind: 'blank' }
   | { kind: 'delivered', timestamp: Date }
   | { kind: 'read', timestamp: Date }
-  | { kind: 'unread' }
-  | { kind: 'upsell' };
+  | { kind: 'unread' };
 
 type Side = 'delivered' | 'status';
 
@@ -36,7 +35,6 @@ const contentText = (content: Content): string => {
     case 'delivered': return deliveredText(content.timestamp);
     case 'read': return `Seen ${longFriendlyTimestamp(content.timestamp)}`;
     case 'unread': return 'Not seen yet';
-    case 'upsell': return 'Get read receipts';
   }
 };
 
@@ -57,7 +55,7 @@ const receiptContent = ({
   return (
     readAt ? { kind: 'read', timestamp: readAt } :
     hasGold ? { kind: 'unread' } :
-    { kind: 'upsell' }
+    { kind: 'blank' }
   );
 };
 

--- a/frontend/components/conversation-screen/message-receipt.tsx
+++ b/frontend/components/conversation-screen/message-receipt.tsx
@@ -1,9 +1,5 @@
-import { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS } from 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
 import { DefaultText } from '../default-text';
-import { showPointOfSale } from '../modal/point-of-sale-modal';
 import { useAppTheme } from '../../app-theme/app-theme';
 import { CrossFadeText } from '../cross-fade';
 import { useReadReceipt } from '../../chat/application-layer/hooks/read-receipt';
@@ -31,44 +27,20 @@ const MessageReceipt = ({
 
   const content = receiptContent({ deliveredAt, readAt, hasGold, side });
 
-  const upsellGesture = useMemo(
-    () => Gesture.Tap().onEnd(() => runOnJS(showPointOfSale)(true)),
-    []
-  );
-
   return (
     <CrossFadeText triggerKey={contentKey(content)} style={styles.container}>
-      {content.kind === 'upsell' ?
-        <GestureDetector gesture={upsellGesture}>
-          <View style={styles.upsellTarget}>
-            <DefaultText
-              disableTheme={true}
-              style={{
-                ...styles.upsellText,
-                ...{
-                  color: appTheme.brandColor,
-                  fontSize: appTheme.timestampFontSize,
-                }
-              }}
-            >
-              {contentText(content)}
-            </DefaultText>
-          </View>
-        </GestureDetector>
-      :
-        <DefaultText
-          disableTheme={true}
-          style={{
-            ...styles.text,
-            ...{
-              color: appTheme.hintColor,
-              fontSize: appTheme.timestampFontSize,
-            }
-          }}
-        >
-          {contentText(content)}
-        </DefaultText>
-      }
+      <DefaultText
+        disableTheme={true}
+        style={{
+          ...styles.text,
+          ...{
+            color: appTheme.hintColor,
+            fontSize: appTheme.timestampFontSize,
+          }
+        }}
+      >
+        {contentText(content)}
+      </DefaultText>
     </CrossFadeText>
   );
 };
@@ -80,14 +52,6 @@ const styles = StyleSheet.create({
   },
   text: {
     textAlign: 'right',
-  },
-  upsellTarget: {
-    alignSelf: 'flex-end',
-  },
-  upsellText: {
-    textAlign: 'right',
-    fontWeight: '700',
-    cursor: 'pointer',
   },
 });
 

--- a/frontend/components/conversation-screen/read-receipt-upsell.tsx
+++ b/frontend/components/conversation-screen/read-receipt-upsell.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
+import { DefaultText } from '../default-text';
+import { showPointOfSale } from '../modal/point-of-sale-modal';
+import { useAppTheme } from '../../app-theme/app-theme';
+import { useReadReceiptUpsell } from '../../chat/application-layer/hooks/read-receipt';
+
+const ReadReceiptUpsell = ({ personUuid }: { personUuid: string }) => {
+  const { appTheme } = useAppTheme();
+  const showUpsell = useReadReceiptUpsell(personUuid);
+
+  const upsellGesture = useMemo(
+    () => Gesture.Tap().onEnd(() => runOnJS(showPointOfSale)(true)),
+    []
+  );
+
+  if (!showUpsell) {
+    return null;
+  }
+
+  return (
+    <GestureDetector gesture={upsellGesture}>
+      <View style={styles.container}>
+        <DefaultText
+          disableTheme={true}
+          style={{
+            ...styles.text,
+            ...{
+              color: appTheme.brandColor,
+              fontSize: appTheme.timestampFontSize,
+            }
+          }}
+        >
+          Get read receipts
+        </DefaultText>
+      </View>
+    </GestureDetector>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingRight: 10,
+    justifyContent: 'flex-end',
+  },
+  text: {
+    textAlign: 'right',
+    fontWeight: '700',
+    cursor: 'pointer',
+  },
+});
+
+export {
+  ReadReceiptUpsell,
+};


### PR DESCRIPTION
Closes #1433

Restores the pre-#1371 "Get read receipts" placement: a static (non-animated) pressable line at the end of the message list, just above the text input, shown whenever a non-gold user's message is the last in the conversation. Tapping it opens the point-of-sale modal, and an incoming reply hides it, as before. The own-last-message tracking that #1371 removed (`notifyOwnLastMessageAt`, `useReadReceiptUpsell`) is restored to drive it.

The per-message receipt slot below the speech bubble is otherwise unchanged: the ⟨empty slot⟩ → "Delivered ⟨time⟩" → "Seen ⟨time⟩" cross-fade still settles and toggles by tapping the bubble. The one judgement call: with the upsell moved out of that slot, a non-gold user's status side is now blank (the client can't claim "Not seen yet" when the server never sends them receipts), so "Delivered" fades to an empty line after the usual delay and a bubble tap brings it back.

## Testing

`npm run typecheck`, `npm run lint` and the read-receipt/message-receipt unit tests pass, with new unit tests covering the restored own-last-message tracking. Verified end-to-end in the local app (mobile web): after a non-gold user sends a message, "Delivered ⟨time⟩" appears under the bubble and bold "Get read receipts" sits above the input; the delivered line fades out after 3s and returns on bubble tap; tapping the upsell opens the Gold point-of-sale modal; a reply from the other person clears the upsell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)