### PR TITLE
Stream uncached search results incrementally until a deadline

### DIFF
--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator, Iterable
 from database._row import (
     require_row,
     row_bool,
+    row_float,
     row_int,
     row_int_list_or_none,
     row_int_or_none,

--- a/backend/database/_row.py
+++ b/backend/database/_row.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import TypeVar
 from util.coerce import (
     boolean,
+    floating,
     integer,
     optional_int,
     optional_int_list,
@@ -26,6 +27,10 @@ def row_value(row: Mapping[str, object], key: str) -> object:
 
 def row_bool(row: Mapping[str, object], key: str) -> bool:
     return boolean(row_value(row, key), key)
+
+
+def row_float(row: Mapping[str, object], key: str) -> float:
+    return floating(row_value(row, key), key)
 
 
 def row_int(row: Mapping[str, object], key: str) -> int:

--- a/backend/search/__init__.py
+++ b/backend/search/__init__.py
@@ -1,18 +1,20 @@
 import json
 import psycopg
+import time
 import duotypes as t
 import sessioncache
 from qanda import personality
 from pydantic import ValidationError
-from database import Tx, api_tx, row_int
+from database import Row, Tx, api_tx, row_int
 from qanda.question import Q_QUESTION_SCORE_VECTORS
 from rediscache import redis_cache
 from collections.abc import Sequence
 from typing import Literal, Tuple
-from searchfilters import Q_SEARCH_PARAMETERS
+from searchfilters import Q_SEARCH_PARAMETERS, SearchParam
 from search.sql import (
     Q_APPLY_CLUB_PREFERENCE,
     Q_CACHED_SEARCH,
+    Q_INSERT_SEARCH_CACHE,
     Q_PUBLIC_SEARCH,
     Q_PUBLIC_SEARCH_WITH_ANSWERS,
     Q_QUIZ_SEARCH,
@@ -20,9 +22,19 @@ from search.sql import (
     Q_FEED,
     Q_FEED_V2,
     build_uncached_search,
+    search_cache_insert_params,
 )
 from dataclasses import dataclass
 from datetime import datetime
+
+
+SEARCH_TIMEOUT_MS = 10_000
+
+UNCACHED_SEARCH_FETCH_SECONDS = 10.0 # TODO
+
+UNCACHED_SEARCH_FETCH_BATCH_SIZE = 10
+
+MAX_SEARCH_CANDIDATES = 750
 
 
 @dataclass
@@ -40,6 +52,55 @@ async def _quiz_search_results(
 
     await tx.execute(Q_QUIZ_SEARCH, params)
     return await tx.fetchall()
+
+
+async def _fetch_search_candidates(
+    tx: Tx,
+    uncached_search: str,
+    params: dict[str, SearchParam],
+) -> list[Row]:
+    deadline = time.monotonic() + UNCACHED_SEARCH_FETCH_SECONDS
+    candidates: list[Row] = []
+
+    async with tx.connection.cursor(
+        name='uncached_search',
+        scrollable=False,
+    ) as cursor:
+        print('Executing...', datetime.now()) # TODO
+        await cursor.execute(uncached_search, params)
+        print('Executed!', datetime.now()) # TODO
+        print('Saving...', datetime.now()) # TODO
+        await tx.execute('SAVEPOINT uncached_search_fetch')
+        print('Saved!', datetime.now()) # TODO
+
+        print('Starting batch fetch...', datetime.now()) # TODO
+        i = 1
+        while True:
+            remaining_ms = int(1000 * (deadline - time.monotonic()))
+            if remaining_ms <= 0:
+                break
+
+            await tx.execute(f'SET LOCAL statement_timeout = {remaining_ms}')
+
+            try:
+                batch = await cursor.fetchmany(
+                    UNCACHED_SEARCH_FETCH_BATCH_SIZE)
+                print('batch', i, datetime.now()) # TODO
+                i += 1
+            except psycopg.errors.QueryCanceled:
+                await tx.execute('ROLLBACK TO SAVEPOINT uncached_search_fetch')
+                break
+
+            candidates.extend(batch)
+
+            if len(candidates) >= MAX_SEARCH_CANDIDATES:
+                del candidates[MAX_SEARCH_CANDIDATES:]
+                break
+
+            if len(batch) < UNCACHED_SEARCH_FETCH_BATCH_SIZE:
+                break
+
+    return candidates
 
 
 async def _uncached_search_results(
@@ -64,9 +125,21 @@ async def _uncached_search_results(
     try:
         await tx.execute('SET LOCAL jit = off')
         await tx.execute("SET LOCAL hnsw.iterative_scan = strict_order")
+        await tx.execute('SET LOCAL hnsw.max_scan_tuples = 300000')
+        await tx.execute('SET LOCAL cursor_tuple_fraction = 0.01')
+        await tx.execute("SET LOCAL work_mem = '64MB'")
+
+        candidates = await _fetch_search_candidates(
+            tx, uncached_search, params)
+
+        await tx.execute(f'SET LOCAL statement_timeout = {SEARCH_TIMEOUT_MS}')
 
         await tx.execute(Q_DELETE_SEARCH_CACHE, params)
-        await tx.execute(uncached_search, params)
+        if candidates:
+            await tx.execute(
+                Q_INSERT_SEARCH_CACHE,
+                {**params, **search_cache_insert_params(candidates)},
+            )
         await tx.execute(Q_CACHED_SEARCH, params)
         return await tx.fetchall()
     except psycopg.errors.QueryCanceled:
@@ -134,7 +207,7 @@ async def get_search(
     )
 
     async with api_tx('READ COMMITTED') as tx:
-        await tx.execute('SET LOCAL statement_timeout = 10000') # 10 seconds
+        await tx.execute(f'SET LOCAL statement_timeout = {SEARCH_TIMEOUT_MS}')
 
         await tx.execute(Q_APPLY_CLUB_PREFERENCE, params)
 

--- a/backend/search/sql/__init__.py
+++ b/backend/search/sql/__init__.py
@@ -10,9 +10,11 @@ from search.sql.search import (
     Q_APPLY_CLUB_PREFERENCE,
     Q_CACHED_SEARCH,
     Q_DELETE_SEARCH_CACHE,
+    Q_INSERT_SEARCH_CACHE,
     Q_QUIZ_SEARCH,
     Q_UPSERT_SEARCH_PREFERENCE_CLUB,
     build_uncached_search,
+    search_cache_insert_params,
 )
 
 __all__ = [
@@ -21,9 +23,11 @@ __all__ = [
     'Q_DELETE_SEARCH_CACHE',
     'Q_FEED',
     'Q_FEED_V2',
+    'Q_INSERT_SEARCH_CACHE',
     'Q_PUBLIC_SEARCH',
     'Q_PUBLIC_SEARCH_WITH_ANSWERS',
     'Q_QUIZ_SEARCH',
     'Q_UPSERT_SEARCH_PREFERENCE_CLUB',
     'build_uncached_search',
+    'search_cache_insert_params',
 ]

--- a/backend/search/sql/search.py
+++ b/backend/search/sql/search.py
@@ -1,4 +1,13 @@
-from database import Row, row_bool, row_int, row_str, row_str_or_none
+from database import (
+    Row,
+    row_bool,
+    row_float,
+    row_int,
+    row_int_or_none,
+    row_str,
+    row_str_or_none,
+)
+from typing import TypeAlias
 from searchfilters import (
     SearchParam,
     and_clauses,
@@ -115,11 +124,11 @@ _VERIFICATION_SATISFIED = sql_fragment("""
 _PROSPECT_SELECT = """    SELECT
         prospect.id AS prospect_person_id,
 
-        uuid AS prospect_uuid,
+        uuid::TEXT AS prospect_uuid,
 
         name,
 
-        prospect.personality,
+        prospect.personality::TEXT AS personality,
 
         verification_level_id > 1 AS verified,
 
@@ -137,7 +146,7 @@ _PROSPECT_SELECT = """    SELECT
 
         CASE
             WHEN show_my_age
-            THEN EXTRACT(YEAR FROM AGE(prospect.date_of_birth))
+            THEN EXTRACT(YEAR FROM AGE(prospect.date_of_birth))::SMALLINT
             ELSE NULL
         END AS age,
 
@@ -280,7 +289,6 @@ def build_uncached_search(
     ])
 
     sql = f"""
-WITH candidates AS (
 {_PROSPECT_SELECT}
     FROM
 {_from_clause(club_preference)}
@@ -288,15 +296,76 @@ WITH candidates AS (
         {where}
 
     ORDER BY
-        prospect.personality <#> %(searcher_personality)s::VECTOR
-
-    LIMIT
-        750
-{_SEARCH_CACHE_INSERT}"""
+        prospect.personality <#> %(searcher_personality)s::VECTOR"""
 
     return sql, params
 
 
+Q_INSERT_SEARCH_CACHE = f"""
+WITH candidates AS (
+    SELECT
+        prospect_person_id,
+        prospect_uuid::UUID AS prospect_uuid,
+        profile_photo_uuid,
+        name,
+        age,
+        match_percentage,
+        personality::VECTOR AS personality,
+        verified
+    FROM
+        UNNEST(
+            %(prospect_person_ids)s::INT[],
+            %(prospect_uuids)s::TEXT[],
+            %(profile_photo_uuids)s::TEXT[],
+            %(names)s::TEXT[],
+            %(ages)s::SMALLINT[],
+            %(match_percentages)s::FLOAT8[],
+            %(personalities)s::TEXT[],
+            %(verifieds)s::BOOLEAN[]
+        ) AS candidate(
+            prospect_person_id,
+            prospect_uuid,
+            profile_photo_uuid,
+            name,
+            age,
+            match_percentage,
+            personality,
+            verified
+        )
+{_SEARCH_CACHE_INSERT}"""
+
+
+SearchCacheInsertParam: TypeAlias = (
+    list[int]
+    | list[int | None]
+    | list[str]
+    | list[str | None]
+    | list[float]
+    | list[bool]
+)
+
+
+def search_cache_insert_params(
+    candidates: list[Row],
+) -> dict[str, SearchCacheInsertParam]:
+    return dict(
+        prospect_person_ids=[
+            row_int(c, 'prospect_person_id') for c in candidates],
+        prospect_uuids=[
+            row_str(c, 'prospect_uuid') for c in candidates],
+        profile_photo_uuids=[
+            row_str_or_none(c, 'profile_photo_uuid') for c in candidates],
+        names=[
+            row_str(c, 'name') for c in candidates],
+        ages=[
+            row_int_or_none(c, 'age') for c in candidates],
+        match_percentages=[
+            row_float(c, 'match_percentage') for c in candidates],
+        personalities=[
+            row_str(c, 'personality') for c in candidates],
+        verifieds=[
+            row_bool(c, 'verified') for c in candidates],
+    )
 
 
 Q_CACHED_SEARCH = """

--- a/backend/search/sql/test_search.py
+++ b/backend/search/sql/test_search.py
@@ -7,7 +7,9 @@ from search.sql.search import (
     _SEARCHER_DIDNT_MESSAGE_PROSPECT,
     _SEARCHER_DIDNT_SKIP_PROSPECT,
     _VERIFICATION_SATISFIED,
+    Q_INSERT_SEARCH_CACHE,
     build_uncached_search,
+    search_cache_insert_params,
     search_only_clauses,
 )
 from searchfilters import (
@@ -93,6 +95,52 @@ class TestMatchesSearchFiltersMirrorsSearch(unittest.TestCase):
         self.assertFalse(
             frozenset(search_only_clauses(prefs))
             & frozenset(prospect_filters(prefs).clauses),
+        )
+
+
+class TestUncachedSearchStreams(unittest.TestCase):
+    def test_uncached_search_is_read_only(self) -> None:
+        search_sql, _ = build_uncached_search(1, 10, 0, maximal_prefs())
+
+        self.assertNotIn('INSERT', search_sql.upper())
+        self.assertNotIn('search_cache', search_sql)
+
+    def test_uncached_search_has_no_pipeline_breakers(self) -> None:
+        search_sql, _ = build_uncached_search(1, 10, 0, maximal_prefs())
+
+        self.assertNotIn('ROW_NUMBER', search_sql.upper())
+        self.assertNotIn('COUNT(', search_sql.upper())
+
+
+class TestSearchCacheInsert(unittest.TestCase):
+    def test_insert_params_match_query_placeholders(self) -> None:
+        for name in search_cache_insert_params([]):
+            self.assertIn(f'%({name})s', Q_INSERT_SEARCH_CACHE)
+
+    def test_insert_params_map_candidate_rows_to_columns(self) -> None:
+        candidate: Row = dict(
+            prospect_person_id=5,
+            prospect_uuid='b1b8bdbb-c67f-42d1-a5eb-77b0c9871ac9',
+            profile_photo_uuid=None,
+            name='Kim',
+            age=None,
+            match_percentage=99.5,
+            personality='[1,0]',
+            verified=True,
+        )
+
+        self.assertEqual(
+            search_cache_insert_params([candidate]),
+            dict(
+                prospect_person_ids=[5],
+                prospect_uuids=['b1b8bdbb-c67f-42d1-a5eb-77b0c9871ac9'],
+                profile_photo_uuids=[None],
+                names=['Kim'],
+                ages=[None],
+                match_percentages=[99.5],
+                personalities=['[1,0]'],
+                verifieds=[True],
+            ),
         )
 
 

--- a/backend/util/coerce.py
+++ b/backend/util/coerce.py
@@ -20,6 +20,12 @@ def integer(value: object, field_name: str | None = None) -> int:
     return value
 
 
+def floating(value: object, field_name: str | None = None) -> float:
+    if not isinstance(value, float):
+        raise RuntimeError(_message('a float', field_name))
+    return value
+
+
 def number(value: object, field_name: str | None = None) -> int | float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RuntimeError(_message('number', field_name))


### PR DESCRIPTION
## Problem

Searches with broad-but-selective filters (e.g. "last online: all time" plus several answer filters) exceed the 10s `statement_timeout`. Because the uncached search ran as a single `INSERT ... SELECT` with pipeline-breaking sort/window nodes, a timeout rolled back everything and the user saw "no matches found" after ten blank seconds. Addresses #1449.

## Approach

- `build_uncached_search` now returns a pure streaming `SELECT` (no CTE barrier, no `INSERT` tail, no server-side `LIMIT`).
- The executor consumes it through a server cursor in batches of 10 against a wall-clock deadline. Each `FETCH` runs under a `statement_timeout` equal to the remaining budget, and a `SAVEPOINT` lets a cancelled fetch keep the rows already received.
- Plan choice is delegated to Postgres: `SET LOCAL cursor_tuple_fraction = 0.01` tells the planner this cursor is consumed incrementally, so it optimises for early rows and picks streaming plans on its own. (The old server-side `LIMIT 750` silently overrode that preference, which is why it moved client-side.)
- Whatever arrived in time is ranked and upserted into `search_cache` by a separate query fed the rows via `UNNEST`, replicating the previous ordering exactly, then the first page is served from the cache — all in one transaction.

## Behaviour

- With enough time to fetch all 750 candidates, results are identical to the previous implementation.
- Under time pressure, the nearest matches found so far are returned instead of nothing. Benchmarked against a prod-scale copy: the reproduced #1449 search returns results where it previously returned an empty page.
- Very sparse searches can still truncate below their full match count due to HNSW iterative-scan limits (`hnsw.max_scan_tuples` / scan memory); partial results are always the nearest matches.

## Still TODO (draft)

- Remove temporary debug `print()` calls (marked `# TODO`).
- Settle the fetch deadline (`UNCACHED_SEARCH_FETCH_SECONDS`, currently a `# TODO` value used for local testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)