### PR TITLE
Only run CI for the directory that changed

### DIFF
--- a/.github/workflows/backend-publish.yml
+++ b/.github/workflows/backend-publish.yml
@@ -1,6 +1,10 @@
 name: Backend Publish
 
-on: [push]
+on:
+  push:
+    paths:
+      - backend/**
+      - .github/workflows/backend-publish.yml
 
 # Docker builds run from the backend subdirectory, so `-f api.Dockerfile .`
 # uses backend/ as the build context exactly as before.

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - backend/**
+      - .github/workflows/backend-test.yml
   pull_request:
     branches:
       - main
+    paths:
+      - backend/**
+      - .github/workflows/backend-test.yml
 
 # All run-steps below execute from the backend subdirectory, so the
 # relative paths inherited from the original backend repo

--- a/.github/workflows/frontend-eslint.yml
+++ b/.github/workflows/frontend-eslint.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-eslint.yml
   pull_request:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-eslint.yml
 
 defaults:
   run:

--- a/.github/workflows/frontend-jest.yml
+++ b/.github/workflows/frontend-jest.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-jest.yml
   pull_request:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-jest.yml
 
 defaults:
   run:

--- a/.github/workflows/frontend-playwright.yml
+++ b/.github/workflows/frontend-playwright.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-playwright.yml
   pull_request:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-playwright.yml
 
 defaults:
   run:

--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-publish.yml
   pull_request:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-publish.yml
 
 defaults:
   run:

--- a/.github/workflows/frontend-type-checks.yml
+++ b/.github/workflows/frontend-type-checks.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-type-checks.yml
   pull_request:
     branches:
       - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-type-checks.yml
 
 defaults:
   run:


### PR DESCRIPTION
The publish and test workflows currently run on every push, redeploying and retesting everything even when the relevant directory is untouched:

- **Frontend Publish** ran on every push and PR against main, republishing both Cloudflare Pages projects for backend-only changes.
- **Backend Publish** ran on every push to any branch, building and pushing all four Docker images (api, cron, firehol, postgres) for frontend-only changes.
- **Backend Tests**, **Frontend ESLint**, **Frontend Jest Tests**, **Frontend Playwright Tests**, and **Frontend Type Checks** all ran on every push and PR against main regardless of what changed.

This adds `paths` filters so each workflow only runs when its directory (`frontend/**` / `backend/**`) or its own workflow file changes. The backend test harness's dependencies (`docker-compose.test.yml`, test scripts) all live under `backend/`, so nothing outside the filtered paths affects test outcomes.

Note: main has no required status checks in its branch protection, so skipped workflows won't block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)