### PR TITLE
Bring back the mobile search refresh

### DIFF
--- a/frontend/components/search-tab.tsx
+++ b/frontend/components/search-tab.tsx
@@ -2,6 +2,7 @@ import {
   LayoutChangeEvent,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -640,7 +641,7 @@ const SearchScreen_ = ({navigation}: SearchScreenProps) => {
   return (
     <View style={styles.safeAreaView}>
       <DuoliciousTopNavBar>
-        {!isMobile() &&
+        {Platform.OS === 'web' &&
           <TopNavBarButton
             onPress={onPressRefresh}
             iconName="refresh"
@@ -692,7 +693,6 @@ const SearchScreen_ = ({navigation}: SearchScreenProps) => {
         }
         ref={listRef}
         innerRef={observeListRef}
-        disableRefresh={true}
         emptyText={
           "No matches found. Try adjusting your search filters to include " +
           "more people."


### PR DESCRIPTION
Fixes #1487.

Search results lost both manual refresh paths in #1039 ("Smarter auto refresh", commit b9dc8d5d). That PR added `disableRefresh={true}` to the results list, turning off pull-to-refresh on every platform, and narrowed the refresh button's condition from `Platform.OS === 'web'` to `!isMobile()`, hiding it on mobile web. Automatic refetching only fires when a search filter or a Q&A answer changes, so on mobile there was no longer any way to ask for fresh results.

This restores the arrangement the feed tab still uses: pull-to-refresh on native, a refresh button on web (desktop and mobile).

## Verification

Ran the app as Expo web against a stubbed search endpoint that returns a differently-named batch of profiles on each fetch.

- Mobile web (iPhone 13 context): the refresh button renders at the top left of the nav bar, clear of the Duolicious wordmark, and tapping it swapped the list from batch 1 to batch 2.
- Desktop web: unchanged, refresh still refetches.
- Native pull-to-refresh can't be exercised in a browser — the change only drops `disableRefresh`, restoring the same `onRefresh` wiring the feed and inbox lists already use on native, but it's worth a sanity check on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
