### PR TITLE
Mount web tabs lazily

### DIFF
--- a/frontend/components/navigation/web-navigator.tsx
+++ b/frontend/components/navigation/web-navigator.tsx
@@ -5,6 +5,7 @@ import {
   type ViewStyle,
   useWindowDimensions,
 } from 'react-native';
+import { useState } from 'react';
 import {
   createNavigatorFactory,
   type DefaultNavigatorOptions,
@@ -107,6 +108,14 @@ function WebNavigator<Navigation>({
 
   const { width: windowWidth } = useWindowDimensions();
 
+  const focusedRouteKey = state.routes[state.index].key;
+
+  const [loadedRouteKeys, setLoadedRouteKeys] = useState([focusedRouteKey]);
+
+  if (!loadedRouteKeys.includes(focusedRouteKey)) {
+    setLoadedRouteKeys([...loadedRouteKeys, focusedRouteKey]);
+  }
+
   return (
     <NavigationContent>
       <View
@@ -126,6 +135,16 @@ function WebNavigator<Navigation>({
         </View>
         <View style={[CONTENT_COLUMN_STYLE, { height: '100%' }]}>
           {state.routes.map((route, i) => {
+            const isFocused = i === state.index;
+
+            if (
+              !isFocused &&
+              !loadedRouteKeys.includes(route.key) &&
+              !state.preloadedRouteKeys.includes(route.key)
+            ) {
+              return null;
+            }
+
             return (
               <View
                 key={route.key}
@@ -133,7 +152,7 @@ function WebNavigator<Navigation>({
                   StyleSheet.absoluteFill,
                   {
                     paddingHorizontal: 20,
-                    display: i === state.index ? 'flex' : 'none',
+                    display: isFocused ? 'flex' : 'none',
                     borderRightWidth: 1,
                     borderColor: 'black',
                   },


### PR DESCRIPTION
Fixes #1505.

## The bug

Opening someone's profile on the web app immediately fired requests the user never asked for:

```
GET /search?n=3&o=0
GET /next-questions?n=20&o=0
GET /profile-info
```

## Why

Deep-linking (or refreshing) onto a prospect profile synthesizes a `Home` route *beneath* the prospect screen, so the in-screen back button lands on a sensible tab rather than Q&A (`withHomeBackStack` in `frontend/navigation/startup.tsx`).

`WebNavigator` then rendered **every** route in `Home`'s tab state, hiding the unfocused ones with `display: none`. So the Q&A, Search and Profile tabs all mounted and ran their `useEffect` fetches — the Q&A tab's card stack accounts for the `/search` and `/next-questions` calls in the ticket, the Profile tab for `/profile-info`.

Every built-in React Navigation view mounts a screen the first time it is focused and leaves it mounted afterwards. `WebNavigator` is the only navigator in the app that didn't, which is why the mobile app was unaffected.

## The fix

Track focused routes the way `BottomTabView` does — a `useState` list appended to during render, which is React's sanctioned way to derive state from props — and skip rendering a route that has been neither focused nor preloaded. Once mounted, a tab stays mounted, so switching away and back does not refetch or lose scroll position.

## Verification

Driven with Playwright against a local Expo web build with a stubbed API, signed in, recording every API request.

Opening a profile — before:

```
POST /check-session-token
GET  /search?n=3&o=0
GET  /next-questions?n=20&o=0
GET  /profile-info
GET  /prospect-profile/<uuid>
```

after:

```
POST /check-session-token
GET  /prospect-profile/<uuid>
```

Tabs still load on demand, exactly once each:

| action | requests |
| --- | --- |
| cold load of `/qa` | `/search?n=3&o=0`, `/next-questions?n=20&o=0` |
| click Search | `/search?n=10&o=0&club=%00` |
| click Feed | `/feed-v2?before=…` |
| click back to Q&A | *(none)* |
| click back to Search | *(none)* |

`tsc --noEmit`, `eslint` and the Jest suite (229 tests) all pass. The Playwright suite wasn't run locally because its dev server wants port 8081, which was in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
