### PR TITLE
Ignore a repeated back press while the gallery is closing

### DIFF
--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -539,6 +539,8 @@ const GalleryScreen = ({
   }, [navigation, close, finishAndPop]);
 
   const onPressBack = useCallback(() => {
+    if (isFinishing.current) return;
+
     if (navigation.canGoBack()) {
       navigation.goBack();
       return;


### PR DESCRIPTION
Fixes #1507.

## What was happening

Pressing escape in the gallery twice in quick succession — which a keyboard that isn't debouncing properly does from a single press — navigated back past the profile to the search tab.

The two presses cause two pops:

1. Press one calls `navigation.goBack()`. The gallery's `beforeRemove` listener calls `e.preventDefault()`, starts the close animation, and holds the `GO_BACK` action to dispatch itself once the photo has morphed back into the profile.
2. Press two calls `goBack()` again while that animation is still running. The listener's `isFinishing` guard — which exists so the close's own dispatch in step 1 isn't prevented in turn — lets this removal straight through, so the gallery pops immediately.
3. The animation lands and dispatches the action it was holding. The gallery has already left the stack by then, so that second `GO_BACK` pops the profile underneath, landing the user on search.

## The fix

Once the close is running the screen is already on its way out, so `onPressBack` now drops any further back request rather than asking the navigator to pop again. That covers the escape key, the Android hardware back button and drag-to-dismiss, which all route through it. The on-screen back button was already unpressable while closing, via the back-button claim's `closing` flag — this brings the rest into line with it.

Frontend suite, `tsc --noEmit` and eslint are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
