### PR TITLE
Only fetch GIFs while the GIF picker is open

### DIFF
--- a/frontend/components/modal/gif-picker-modal.tsx
+++ b/frontend/components/modal/gif-picker-modal.tsx
@@ -223,8 +223,11 @@ const GifPickerModal: React.FC = () => {
   );
 
   useEffect(() => {
+    if (!isShowing) {
+      return;
+    }
     debouncedFetchGifs(searchQuery);
-  }, [searchQuery, debouncedFetchGifs]);
+  }, [isShowing, searchQuery, debouncedFetchGifs]);
 
   useEffect(() => {
     return listen('show-gif-picker', () => {
@@ -232,9 +235,8 @@ const GifPickerModal: React.FC = () => {
       setSelectedGif(null);
       setSearchQuery('');
       setGifResults([]);
-      debouncedFetchGifs("");
     });
-  }, [debouncedFetchGifs]);
+  }, []);
 
   // Divide gifResults equally between three columns
   const columns = _.times<KlipyGif[]>(NUM_COLS, () => []);


### PR DESCRIPTION
Closes #1511.

## The cause

`GifPickerModal` is rendered unconditionally at the app root (`App.tsx`), so it mounts on every app load, not when a conversation is opened. Its search effect

```js
useEffect(() => {
  debouncedFetchGifs(searchQuery);
}, [searchQuery, debouncedFetchGifs]);
```

therefore ran on mount with the initial empty `searchQuery`, producing exactly the request in the ticket:

```
https://api.klipy.com/api/v1/<key>/gifs/search?q=&page=1&per_page=24
```

It is not specific to profiles — any web app load fires it, including a signed-out visit to `/`.

## The fix

Gate the effect on `isShowing`. Opening the picker sets `isShowing` and resets `searchQuery` in the same batch, so the effect now issues the initial trending fetch itself and the listener's explicit `debouncedFetchGifs("")` is redundant — removing it also keeps the open to a single request rather than two.

## Verification

Driven in Chrome via Playwright against a local Expo web build, counting requests to `api.klipy.com`.

| | before | after |
|---|---|---|
| Load `/` | 1 search request (`q=`) | 0 |
| Open the GIF picker | — | 1 search request (`q=`) |
| Type "cat" | — | 1 further request (`q=cat`) |

GIFs render in the picker and search results update as expected. `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)