### PR TITLE
Offer the matching model as a third "Sort By" option

### DIFF
--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -794,6 +794,7 @@ CREATE UNLOGGED TABLE IF NOT EXISTS search_cache (
     age SMALLINT,
     match_percentage SMALLINT NOT NULL,
     club_distance REAL NOT NULL DEFAULT 0,
+    kv_distance REAL NOT NULL DEFAULT 0,
     personality VECTOR(47) NOT NULL,
     PRIMARY KEY (searcher_person_id, position)
 );
@@ -992,6 +993,7 @@ INSERT INTO last_online (name, seconds) VALUES ('A week ago', 604800) ON CONFLIC
 SELECT setval('sort_by_id_seq', (SELECT COALESCE(MAX(id), 0) + 1 FROM sort_by), FALSE);
 INSERT INTO sort_by (name) VALUES ('Match percentage') ON CONFLICT (name) DO NOTHING;
 INSERT INTO sort_by (name) VALUES ('Similar clubs') ON CONFLICT (name) DO NOTHING;
+INSERT INTO sort_by (name) VALUES ('Longer conversations') ON CONFLICT (name) DO NOTHING;
 INSERT INTO last_online (name, seconds) VALUES ('{{LAST_ONLINE_DEFAULT_NAME}}', {{LAST_ONLINE_DEFAULT_SECONDS}}) ON CONFLICT (name) DO NOTHING;
 INSERT INTO last_online (name, seconds) VALUES ('All time', 3153600000) ON CONFLICT (name) DO NOTHING;
 

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -18,3 +18,8 @@ ALTER TABLE person
 ALTER TABLE person
     ADD COLUMN IF NOT EXISTS kv_vector_computed_at TIMESTAMP NOT NULL
     DEFAULT to_timestamp(0);
+
+ALTER TABLE search_cache
+    ADD COLUMN IF NOT EXISTS kv_distance REAL NOT NULL DEFAULT 0;
+
+INSERT INTO sort_by (name) VALUES ('Longer conversations') ON CONFLICT (name) DO NOTHING;

--- a/backend/service/api/search/__init__.py
+++ b/backend/service/api/search/__init__.py
@@ -4,7 +4,7 @@ import service.api.duotypes as t
 from service.api import sessioncache
 from service.api.qanda import personality
 from pydantic import ValidationError
-from serviceshared.database import Tx, api_tx, row_bool, row_int
+from serviceshared.database import Tx, api_tx, row_int, row_str
 from serviceshared.pgvector import to_pgvector
 from service.api.qanda.question import Q_QUESTION_SCORE_VECTORS
 from service.api.search.rediscache import redis_cache
@@ -16,7 +16,7 @@ from service.api.search.sql import (
     Q_CACHED_SEARCH,
     Q_PUBLIC_SEARCH,
     Q_PUBLIC_SEARCH_WITH_ANSWERS,
-    Q_SORT_BY_CLUBS,
+    Q_SORT_BY,
     Q_DELETE_SEARCH_CACHE,
     Q_FEED,
     Q_FEED_V2,
@@ -40,12 +40,12 @@ async def _quiz_search_results(
         searcher_person_id=searcher_person_id,
     )
 
-    sort_by_clubs = row_bool(
-        await tx.require_one(Q_SORT_BY_CLUBS, params),
-        'sort_by_clubs',
+    sort_by = row_str(
+        await tx.require_one(Q_SORT_BY, params),
+        'sort_by',
     )
 
-    await tx.execute(build_quiz_search(sort_by_clubs), params)
+    await tx.execute(build_quiz_search(sort_by), params)
     return await tx.fetchall()
 
 

--- a/backend/service/api/search/sql/__init__.py
+++ b/backend/service/api/search/sql/__init__.py
@@ -11,7 +11,7 @@ from service.api.search.sql.search import (
     Q_CACHED_SEARCH,
     Q_DELETE_SEARCH_CACHE,
     Q_SET_SEARCH_PREFERENCE_CLUB,
-    Q_SORT_BY_CLUBS,
+    Q_SORT_BY,
     build_quiz_search,
     build_uncached_search,
 )
@@ -25,7 +25,7 @@ __all__ = [
     'Q_PUBLIC_SEARCH',
     'Q_PUBLIC_SEARCH_WITH_ANSWERS',
     'Q_SET_SEARCH_PREFERENCE_CLUB',
-    'Q_SORT_BY_CLUBS',
+    'Q_SORT_BY',
     'build_quiz_search',
     'build_uncached_search',
 ]

--- a/backend/service/api/search/sql/search.py
+++ b/backend/service/api/search/sql/search.py
@@ -108,9 +108,17 @@ _VERIFICATION_SATISFIED = sql_fragment("""
 _CLUB_DISTANCE = \
     'prospect.club_vector <#> %(searcher_club_vector)s::VECTOR'
 
+_KV_DISTANCE = \
+    'prospect.kv_vector <#> %(searcher_kv_vector)s::HALFVEC'
 
-def _prospect_select(sort_by_clubs: bool) -> str:
-    club_distance = _CLUB_DISTANCE if sort_by_clubs else '0::REAL'
+SORT_MATCH = 'Match percentage'
+SORT_CLUBS = 'Similar clubs'
+SORT_KV = 'Longer conversations'
+
+
+def _prospect_select(sort_by: str) -> str:
+    club_distance = _CLUB_DISTANCE if sort_by == SORT_CLUBS else '0::REAL'
+    kv_distance = _KV_DISTANCE if sort_by == SORT_KV else '0::REAL'
 
     return f"""    SELECT
         prospect.id AS prospect_person_id,
@@ -147,13 +155,19 @@ def _prospect_select(sort_by_clubs: bool) -> str:
             100 * (1 - (prospect.personality <#> %(searcher_personality)s::VECTOR)) / 2
         ) AS match_percentage,
 
-        {club_distance} AS club_distance"""
+        {club_distance} AS club_distance,
 
-def _rank(sort_by_clubs: bool) -> str:
-    return 'club_distance' if sort_by_clubs else 'match_percentage DESC'
+        {kv_distance} AS kv_distance"""
+
+def _rank(sort_by: str) -> str:
+    if sort_by == SORT_CLUBS:
+        return 'club_distance'
+    if sort_by == SORT_KV:
+        return 'kv_distance'
+    return 'match_percentage DESC'
 
 
-def _search_cache_insert(sort_by_clubs: bool) -> str:
+def _search_cache_insert(sort_by: str) -> str:
     return f"""), do_promote_verified AS (
     SELECT
         count(*) >= 250 AS x
@@ -176,6 +190,7 @@ INSERT INTO search_cache (
     age,
     match_percentage,
     club_distance,
+    kv_distance,
     personality,
     verified
 )
@@ -192,7 +207,7 @@ SELECT
                     profile_photo_uuid IS NOT NULL
             END DESC,
 
-            {_rank(sort_by_clubs)}
+            {_rank(sort_by)}
     ) AS position,
     prospect_person_id,
     prospect_uuid,
@@ -201,6 +216,7 @@ SELECT
     age,
     match_percentage,
     club_distance,
+    kv_distance,
     personality,
     verified
 FROM
@@ -219,6 +235,7 @@ ON CONFLICT (searcher_person_id, position) DO UPDATE SET
     age = EXCLUDED.age,
     match_percentage = EXCLUDED.match_percentage,
     club_distance = EXCLUDED.club_distance,
+    kv_distance = EXCLUDED.kv_distance,
     personality = EXCLUDED.personality,
     verified = EXCLUDED.verified
 """
@@ -277,10 +294,12 @@ def build_uncached_search(
     if club_preference is not None:
         params['club_preference'] = club_preference
 
-    sort_by_clubs = row_str(prefs, 'sort_by') == 'Similar clubs'
-    if sort_by_clubs:
+    sort_by = row_str(prefs, 'sort_by')
+    if sort_by == SORT_CLUBS:
         params['searcher_club_vector'] = row_str(
             prefs, 'searcher_club_vector')
+    if sort_by == SORT_KV:
+        params['searcher_kv_vector'] = row_str(prefs, 'searcher_kv_vector')
 
     reverse = two_way_filters(prefs)
     params.update(reverse.params)
@@ -294,15 +313,17 @@ def build_uncached_search(
         *filters.clauses,
     ])
 
-    if sort_by_clubs:
+    if sort_by == SORT_CLUBS:
         candidate_order = _CLUB_DISTANCE
+    elif sort_by == SORT_KV:
+        candidate_order = _KV_DISTANCE
     else:
         candidate_order = \
             'prospect.personality <#> %(searcher_personality)s::VECTOR'
 
     sql = f"""
 WITH candidates AS (
-{_prospect_select(sort_by_clubs)}
+{_prospect_select(sort_by)}
     FROM
 {_from_clause(club_preference)}
     WHERE
@@ -313,7 +334,7 @@ WITH candidates AS (
 
     LIMIT
         750
-{_search_cache_insert(sort_by_clubs)}"""
+{_search_cache_insert(sort_by)}"""
 
     return sql, params
 
@@ -428,9 +449,9 @@ ON
     private_page.prospect_person_id = public_page.prospect_person_id
 """
 
-Q_SORT_BY_CLUBS = """
+Q_SORT_BY = """
 SELECT
-    sort_by.name = 'Similar clubs' AS sort_by_clubs
+    sort_by.name AS sort_by
 FROM
     search_preference
 JOIN
@@ -442,7 +463,7 @@ WHERE
 """
 
 
-def build_quiz_search(sort_by_clubs: bool) -> str:
+def build_quiz_search(sort_by: str) -> str:
     return f"""
 WITH searcher AS (
     SELECT
@@ -514,7 +535,7 @@ WITH searcher AS (
                 profile_photo_uuid IS NOT NULL
         END DESC,
 
-        {_rank(sort_by_clubs)}
+        {_rank(sort_by)}
     LIMIT
         1
 )

--- a/backend/service/api/search/sql/test_search.py
+++ b/backend/service/api/search/sql/test_search.py
@@ -57,6 +57,7 @@ def maximal_prefs() -> Row:
         searcher_person_id=1,
         searcher_coordinates='POINT(0 0)',
         searcher_personality='[0]',
+        searcher_kv_vector='[0]',
         searcher_age=25,
         searcher_height_cm=170,
         searcher_count_answers=1,

--- a/backend/service/api/searchfilters/__init__.py
+++ b/backend/service/api/searchfilters/__init__.py
@@ -264,6 +264,13 @@ SELECT
     ) AS required_answer_question_ids,
     person.coordinates::TEXT AS searcher_coordinates,
     person.personality::TEXT AS searcher_personality,
+    -- `key || value`: the two halves of kv_vector the other way round, so
+    -- that one inner product against a prospect's `value || key` scores both
+    -- directions at once.
+    (
+        subvector(person.kv_vector, 67, 66) ||
+        subvector(person.kv_vector, 1, 66)
+    )::TEXT AS searcher_kv_vector,
     sort_by.name AS sort_by,
     COALESCE(
         (

--- a/frontend/data/option-groups.tsx
+++ b/frontend/data/option-groups.tsx
@@ -460,6 +460,7 @@ const sortByDefault = 'Match percentage';
 const sortByValues = [
   sortByDefault,
   'Similar clubs',
+  'Longer conversations',
 ];
 
 const immediacy = [
@@ -2058,7 +2059,7 @@ const searchOrderOptionGroups: OptionGroup<OptionGroupInputs>[] = [
         style={{ color }}
       />
     ),
-    description: "How should search results be sorted? “Match percentage” shows people with Q&A answers like yours first. “Similar clubs” shows members with clubs like yours first.",
+    description: "How should search results be sorted? “Match percentage” shows people with Q&A answers like yours first. “Similar clubs” shows members with clubs like yours. “Longer conversations” shows people most likely to hold a conversation with you.",
     input: {
       buttons: {
         values: sortByValues,


### PR DESCRIPTION
Second of two stacked PRs — **based on #1514**, which produces the vectors
this one ranks by. Review that first; the diff shown here will include it
until it merges.

Duolicious already ranks prospects two ways, both scoring *content
similarity*: **Match percentage** from Q&A answers, and **Similar clubs**
from co-membership. This adds a third, **Longer conversations**, which ranks
by the key-value model — a searcher's `key || value` against each prospect's
`value || key`, one pgvector inner product like the other two.

## Does it work?

Of 362,179 first messages sent after the training cutoff (held out, not
conditioned on anything):

| ranked by | top 10% got a reply | lift | top 10% reached 20-each-way | lift |
| --- | --- | --- | --- | --- |
| baseline (all messages) | 59.5% | – | 13.5% | – |
| **this model** | **76.6%** | **1.29x** | **23.4%** | **1.73x** |
| similar clubs | 64.8% | 1.09x | 15.6% | 1.15x |
| match percentage | 62.5% | 1.05x | 16.0% | 1.19x |

Only 34% of people have a club vector, so ranking by clubs ties most of the
population at zero and part of that 1.09x is "has clubs at all" acting as an
activity proxy. Restricted to pairs where both have clubs, similar clubs
falls to 1.05x / 1.06x while this model holds at 1.27x / 1.69x.

The option is named for what the model is trained on: for a messaged pair it
regresses `log2(1 + messages sent)`, summed over both directions.

All of this is observational — it can only measure pairs who actually
messaged under the current ranking, so an A/B test settles the magnitude.

## Notes for review

`sort_by_clubs` was a boolean, so it becomes the sort's *name* throughout.
Each ranking expression is computed only when its sort is selected, so
searchers on the other two options pay nothing for this one.

`search_cache` gains `kv_distance` beside `club_distance`, which the quiz
search needs in order to re-sort cached rows by the chosen algorithm.

`match_percentage` stays computed from personality. It is shown to users as
an answer-similarity figure, so ranking changes without the displayed number
moving.

Half precision leaves the top-50 and top-500 orderings identical to float4
while keeping the row narrow enough that the search scan stays off TOAST —
as float4 the same column costs 497ms against 121ms on a prod-scale copy,
where the personality ranking it sits beside costs 105ms.

The feed is deliberately untouched: `/feed-v2`, which the app uses, orders by
`came_online_time` and only *displays* match percentage. Ranking it by this
model would turn a recency feed into a ranked one, which is a product
decision rather than part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)