### PR TITLE
Open profiles in a new tab on ctrl + left click

### DIFF
--- a/frontend/components/avatar.tsx
+++ b/frontend/components/avatar.tsx
@@ -11,7 +11,7 @@ import { DefaultText } from './default-text';
 import {
   IMAGES_URL,
 } from '../env/env';
-import { makeLinkProps } from '../util/navigation'
+import { isOpenInNewTabPress, makeLinkProps } from '../util/navigation'
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { X } from "react-native-feather";
 import { ImageBackground } from "expo-image";
@@ -58,6 +58,10 @@ const Avatar = ({
   const handle = urlSlug || personUuid;
 
   const onPress = useCallback((e: GestureResponderEvent) => {
+    if (isOpenInNewTabPress(e)) {
+      return;
+    }
+
     e.preventDefault();
 
     if (!navigation) {

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -14,7 +14,7 @@ import { DuoliciousTopNavBar } from './top-nav-bar';
 import { useScrollbar } from './navigation/scroll-bar-hooks';
 import { Avatar } from './avatar';
 import { getShortElapsedTime, isMobile, assertNever, capLuminance, formatCount } from '../util/util';
-import { makeLinkProps } from '../util/navigation';
+import { isOpenInNewTabPress, makeLinkProps } from '../util/navigation';
 import { GestureResponderEvent, LayoutChangeEvent, Pressable, Animated, ViewStyle } from 'react-native';
 import { EnlargeablePhoto } from './enlargeable-image';
 import { commonStyles } from '../styles';
@@ -326,6 +326,10 @@ const useNavigationToProfile = (
   const navigation = useNavigation<NativeStackNavigationProp<RootParamList>>();
 
   return useCallback((e: GestureResponderEvent) => {
+    if (isOpenInNewTabPress(e)) {
+      return;
+    }
+
     e.preventDefault();
 
     setProspectHint(handle, { photoBlurhash });
@@ -621,6 +625,10 @@ const FacepileAvatar = ({
   );
 
   const onPress = useCallback((e: GestureResponderEvent) => {
+    if (isOpenInNewTabPress(e)) {
+      return;
+    }
+
     if (navigatesOnPress) {
       navigateToProfile(e);
     } else {
@@ -677,6 +685,10 @@ const ViewerFacepileAvatar = ({
   );
 
   const onPress = useCallback((e: GestureResponderEvent) => {
+    if (isOpenInNewTabPress(e)) {
+      return;
+    }
+
     if (navigatesOnPress) {
       navigateToProfile(e);
     } else {

--- a/frontend/components/profile-card.tsx
+++ b/frontend/components/profile-card.tsx
@@ -28,7 +28,7 @@ import {
 import type { HomeParamList, RootParamList } from '../navigation/linking';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { listen } from '../events/events';
-import { makeLinkProps } from '../util/navigation'
+import { isOpenInNewTabPress, makeLinkProps } from '../util/navigation'
 import { X } from "react-native-feather";
 import { PageItem } from './search-tab';
 import {
@@ -240,6 +240,10 @@ const ProfileCard = ({
   >>();
 
   const itemOnPress = useCallback((e: GestureResponderEvent) => {
+    if (isOpenInNewTabPress(e)) {
+      return;
+    }
+
     e.preventDefault();
 
     if (!navigation) {

--- a/frontend/util/navigation.tsx
+++ b/frontend/util/navigation.tsx
@@ -1,9 +1,17 @@
+import { GestureResponderEvent } from 'react-native';
+
 const makeLinkProps = (link: string) => {
   return {
     href: link
   };
 };
 
+const isOpenInNewTabPress = ({ nativeEvent }: GestureResponderEvent) =>
+  ('ctrlKey' in nativeEvent && nativeEvent.ctrlKey === true) ||
+  ('metaKey' in nativeEvent && nativeEvent.metaKey === true) ||
+  ('shiftKey' in nativeEvent && nativeEvent.shiftKey === true);
+
 export {
-  makeLinkProps
+  isOpenInNewTabPress,
+  makeLinkProps,
 };


### PR DESCRIPTION
Fixes #1523

Profile cards already render as anchors with a real `href`, but react-native-web forwards ctrl/cmd/shift+clicks to `onPress`, and every profile press handler unconditionally called `e.preventDefault()` before navigating in-app — cancelling the browser's native open-in-new-tab behavior.

This adds an `isOpenInNewTabPress` helper that detects ctrl, cmd, and shift modifier clicks; the profile press handlers now return early on those, letting the browser follow the anchor natively. Covers search-tab profile cards, avatars, and the feed's profile links and facepile avatars (a modifier-click on a collapsed facepile opens that member's profile in a new tab instead of spreading the pile). On native platforms the helper always returns false, so behavior is unchanged there. Middle-click already worked, since react-native-web never routes non-primary buttons to `onPress`.

Verified with Playwright against the Expo web build: ctrl+click opens the profile in a new tab while the original tab stays on the feed; a plain click still navigates in the same tab. The unfixed code fails the same test (no new tab opens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)