### PR TITLE
Tell logged-out visitors that most profiles are members-only

### DIFF
--- a/frontend/components/cross-fade.tsx
+++ b/frontend/components/cross-fade.tsx
@@ -60,13 +60,12 @@ const CrossFade = ({
   const mountedAt = useRef(Date.now());
 
   useEffect(() => {
-    if (!showFront) {
-      return;
-    }
-
     const remaining = Math.max(0, minBackMs - (Date.now() - mountedAt.current));
 
-    progress.value = withDelay(remaining, withTiming(1, { duration }));
+    progress.value = withDelay(
+      remaining,
+      withTiming(showFront ? 1 : 0, { duration })
+    );
   }, [showFront]);
 
   return (

--- a/frontend/components/navigation/faq.tsx
+++ b/frontend/components/navigation/faq.tsx
@@ -163,6 +163,23 @@ const FAQ_ITEMS: FaqItem[] = [
     </>,
   },
   {
+    question: 'Is my profile private?',
+    Answer: () => <>
+      <Paragraph>
+        Yes, unless you say otherwise! Only people signed into Duolicious can
+        see your profile. The profiles that signed-out visitors can browse
+        belong to members who turned on the optional ‘Public Profile’ setting,
+        which is off by default.
+      </Paragraph>
+      <Paragraph>
+        If you want even more privacy, you can use ‘Verification Level’ to set
+        the minimum verification people need to find you in search results.
+        You’ll find these options under “Privacy Settings” in the “Profile”
+        tab.
+      </Paragraph>
+    </>,
+  },
+  {
     question: 'Are pics of myself required on my profile?',
     Answer: () => <>
       <Paragraph>

--- a/frontend/components/sign-up-banner.tsx
+++ b/frontend/components/sign-up-banner.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Pressable, View, useWindowDimensions } from 'react-native';
 import { CrossFade, CrossFadeText } from './cross-fade';
 import { DefaultText } from './default-text';
@@ -24,6 +25,15 @@ const SignUpBannerCard = ({ prospectHandle, overContentColumn }: {
   const { width: windowWidth } = useWindowDimensions();
   const numActiveUsers = useNumActiveUsers(undefined);
   const prospectName = useBannerProspectName(prospectHandle);
+  const [showNumActiveUsers, setShowNumActiveUsers] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setShowNumActiveUsers((s) => !s),
+      5000
+    );
+    return () => clearInterval(interval);
+  }, []);
 
   // Longer names blow out the button's width, so fall back to the default copy.
   const label = prospectName && prospectName.length <= 7
@@ -79,37 +89,43 @@ const SignUpBannerCard = ({ prospectHandle, overContentColumn }: {
             gap: 14,
           }}
         >
-          <View
-            style={{
-              flex: 1,
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 12,
-            }}
-          >
-            <Logo16 size={64} color={appTheme.brandColor} rectSize={0.3} />
-            <CrossFade
-              style={{ flexShrink: 1 }}
-              showFront={numActiveUsers !== undefined}
-              minBackMs={2000}
-              front={
-                <>
+          <CrossFade
+            style={{ flex: 1 }}
+            showFront={showNumActiveUsers && numActiveUsers !== undefined}
+            minBackMs={5000}
+            front={
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 12,
+                }}
+              >
+                <Logo16 size={64} color={appTheme.brandColor} rectSize={0.3} />
+                <View style={{ flexShrink: 1 }}>
                   <DefaultText style={{ fontWeight: '900', fontSize: 20 }}>
                     {numActiveUsers === undefined ? '\xa0' : numActiveUsers.toLocaleString()}
                   </DefaultText>
                   <DefaultText style={{ fontWeight: '600', fontSize: 14 }}>
                     Active Members
                   </DefaultText>
-                </>
-              }
-              back={
-                <DefaultText style={{ fontWeight: '600', fontSize: 12 }}>
-                  Online dating, but based and true love-pilled
-                </DefaultText>
-              }
-            />
-          </View>
+                </View>
+              </View>
+            }
+            back={
+              <DefaultText
+                style={{
+                  fontWeight: '700',
+                  fontSize: 14,
+                  textAlign: 'center',
+                  textWrap: 'balance',
+                }}
+              >
+                {'See members\u2011only profiles by joining or signing in'}
+              </DefaultText>
+            }
+          />
           <View style={{ flex: 1 }}>
             <Pressable
               onPress={() => showSignUp(true, signUpMessage)}

--- a/frontend/types/react-native-web.d.ts
+++ b/frontend/types/react-native-web.d.ts
@@ -1,0 +1,7 @@
+import 'react-native';
+
+declare module 'react-native' {
+  interface TextStyle {
+    textWrap?: 'wrap' | 'nowrap' | 'balance' | 'pretty' | 'stable';
+  }
+}


### PR DESCRIPTION
A Reddit user browsing the public search page assumed every profile on Duolicious is publicly visible and decided not to register. Profiles are actually private by default; the public grid only shows members who opted into 'Public Profile'.

This PR addresses that in two places:

- **Sign-up banner**: instead of showing the tagline once during load and then the member count forever, the banner now cross-fades every five seconds between "See members‑only profiles by joining or signing in" and the active-member count (with the hearts logo shown only alongside the count). The sentence is centred and uses `text-wrap: balance` plus a non-breaking hyphen so its lines wrap evenly at narrow widths; a small type augmentation teaches TypeScript that react-native-web passes `textWrap` through to CSS. `CrossFade` is now bidirectional to support the alternation — the banner is its only consumer.
- **FAQ**: a new entry, "Is my profile private?", second in the list, explaining that profiles are members-only unless the owner enables the opt-in 'Public Profile' setting, and pointing to 'Verification Level' for stricter visibility. Gold-gated settings are deliberately not mentioned.

Verified in the browser at desktop, iPhone 13, and iPhone SE widths: both banner states render correctly through full cycles, and the FAQ entry expands with the new copy. `tsc` and the cross-fade tests pass.

Closes #1529

🤖 Generated with [Claude Code](https://claude.com/claude-code)