### PR TITLE
Break up patch_profile_info

### DIFF
--- a/backend/service/api/person/profileinfo/__init__.py
+++ b/backend/service/api/person/profileinfo/__init__.py
@@ -1,5 +1,7 @@
 import logging
 import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass
 
 import service.api.duotypes as t
 from service.api.chat.chatutil import REDIS_WORKER_CLIENT
@@ -129,6 +131,364 @@ async def _patch_profile_info_about(
 
         await tx.execute(update, update_params)
 
+def _person_lookup_q(column: str, table: str) -> str:
+    return f"""
+    UPDATE person SET {column} = {table}.id
+    FROM {table}
+    WHERE person.id = %(person_id)s
+    AND {table}.name = %(field_value)s
+    """
+
+
+def _person_verified_lookup_q(column: str, table: str,
+                              verified_column: str) -> str:
+    return f"""
+    UPDATE person
+    SET {column} = {table}.id, {verified_column} = false
+    FROM {table}
+    WHERE person.id = %(person_id)s
+    AND {table}.name = %(field_value)s
+    AND person.{column} <> {table}.id
+    """
+
+
+def _person_yes_no_q(column: str) -> str:
+    return f"""
+    UPDATE person
+    SET {column} = (
+        CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
+    WHERE id = %(person_id)s
+    """
+
+
+def _person_value_q(column: str) -> str:
+    return f"""
+    UPDATE person SET {column} = %(field_value)s
+    WHERE person.id = %(person_id)s
+    """
+
+
+Q_PATCH_LOCATION = """
+UPDATE person
+SET
+    coordinates
+        = location.coordinates,
+
+    verification_required
+        = location.verification_required OR person.verification_required,
+
+    location_short_friendly
+        = location.short_friendly,
+
+    location_long_friendly
+        = location.long_friendly,
+
+    location_country
+        = location.country
+FROM location
+WHERE person.id = %(person_id)s
+AND long_friendly = %(field_value)s
+"""
+
+Q_PATCH_THEME = """
+UPDATE person
+SET
+    title_color = %(title_color)s,
+    body_color = %(body_color)s,
+    background_color = %(background_color)s
+WHERE id = %(person_id)s
+"""
+
+
+@dataclass(frozen=True)
+class _ProfileField:
+    q1: str
+    q2: str | None = None
+    requires_gold: bool = False
+
+
+_PROFILE_FIELDS = {
+    'gender': _ProfileField(
+        q1=_person_verified_lookup_q('gender_id', 'gender', 'verified_gender'),
+        q2=Q_UPDATE_VERIFICATION_LEVEL,
+    ),
+    'orientation': _ProfileField(
+        q1=_person_lookup_q('orientation_id', 'orientation')),
+    'ethnicity': _ProfileField(
+        q1=_person_verified_lookup_q(
+            'ethnicity_id', 'ethnicity', 'verified_ethnicity'),
+        q2=Q_UPDATE_VERIFICATION_LEVEL,
+    ),
+    'location': _ProfileField(q1=Q_PATCH_LOCATION),
+    'occupation': _ProfileField(q1=_person_value_q('occupation')),
+    'education': _ProfileField(q1=_person_value_q('education')),
+    'height': _ProfileField(q1=_person_value_q('height_cm')),
+    'looking_for': _ProfileField(
+        q1=_person_lookup_q('looking_for_id', 'looking_for')),
+    'smoking': _ProfileField(
+        q1=_person_lookup_q('smoking_id', 'yes_no_optional')),
+    'drinking': _ProfileField(q1=_person_lookup_q('drinking_id', 'frequency')),
+    'drugs': _ProfileField(q1=_person_lookup_q('drugs_id', 'yes_no_optional')),
+    'long_distance': _ProfileField(
+        q1=_person_lookup_q('long_distance_id', 'yes_no_optional')),
+    'relationship_status': _ProfileField(
+        q1=_person_lookup_q('relationship_status_id', 'relationship_status')),
+    'has_kids': _ProfileField(
+        q1=_person_lookup_q('has_kids_id', 'yes_no_maybe')),
+    'wants_kids': _ProfileField(
+        q1=_person_lookup_q('wants_kids_id', 'yes_no_maybe')),
+    'exercise': _ProfileField(q1=_person_lookup_q('exercise_id', 'frequency')),
+    'religion': _ProfileField(q1=_person_lookup_q('religion_id', 'religion')),
+    'star_sign': _ProfileField(q1=_person_lookup_q('star_sign_id', 'star_sign')),
+    'units': _ProfileField(q1=_person_lookup_q('unit_id', 'unit')),
+    'chats': _ProfileField(
+        q1=_person_lookup_q('chats_notification', 'immediacy')),
+    'intros': _ProfileField(
+        q1=_person_lookup_q('intros_notification', 'immediacy')),
+    'visitors': _ProfileField(
+        q1=_person_lookup_q('visitors_notification', 'immediacy')),
+    'verification_level': _ProfileField(
+        q1=_person_lookup_q(
+            'privacy_verification_level_id', 'verification_level')),
+    'show_my_location': _ProfileField(
+        q1=_person_lookup_q('show_my_location_id', 'yes_country_only_no'),
+        requires_gold=True,
+    ),
+    'show_my_age': _ProfileField(
+        q1=_person_yes_no_q('show_my_age'), requires_gold=True),
+    'show_my_looking_for': _ProfileField(
+        q1=_person_yes_no_q('show_my_looking_for'), requires_gold=True),
+    'hide_me_from_strangers': _ProfileField(
+        q1=_person_yes_no_q('hide_me_from_strangers'), requires_gold=True),
+    'browse_invisibly': _ProfileField(
+        q1=_person_yes_no_q('browse_invisibly'), requires_gold=True),
+    'show_my_online_status': _ProfileField(
+        q1=_person_yes_no_q('show_my_online_status')),
+    'public_profile': _ProfileField(q1=_person_yes_no_q('public_profile')),
+    'theme': _ProfileField(q1=Q_PATCH_THEME, requires_gold=True),
+}
+
+
+async def _patch_photo(person_id: int, field_value: object) -> object:
+    base64_file = t.Base64File.model_validate(field_value)
+
+    crop_size = CropSize(
+            top=base64_file.top,
+            left=base64_file.left)
+    uuid = secrets.token_hex(32)
+    blurhash_ = compute_blurhash(base64_file.image, crop_size=crop_size)
+    extra_exts = ['gif'] if base64_file.image.format == 'GIF' else []
+    geometry = photo_geometry(
+        *orient_image(base64_file.image).size,
+        crop_size,
+    )
+
+    params = dict(
+        person_id=person_id,
+        position=base64_file.position,
+        uuid=uuid,
+        blurhash=blurhash_,
+        extra_exts=extra_exts,
+        hash=base64_file.md5_hash,
+        **photo_geometry_params(geometry),
+    )
+
+    q = """
+    WITH existing_uuid AS (
+        SELECT
+            uuid
+        FROM
+            photo
+        WHERE
+            person_id = %(person_id)s
+        AND
+            position = %(position)s
+    ), undeleted_photo_insertion AS (
+        INSERT INTO undeleted_photo (
+            uuid
+        )
+        SELECT
+            uuid
+        FROM
+            existing_uuid
+    ), photo_insertion AS (
+        INSERT INTO photo (
+            person_id,
+            position,
+            uuid,
+            blurhash,
+            extra_exts,
+            hash,
+            width,
+            height,
+            crop_top,
+            crop_left
+        ) VALUES (
+            %(person_id)s,
+            %(position)s,
+            %(uuid)s,
+            %(blurhash)s,
+            %(extra_exts)s,
+            %(hash)s,
+            %(width)s,
+            %(height)s,
+            %(crop_top)s,
+            %(crop_left)s
+        ) ON CONFLICT (person_id, position) DO UPDATE SET
+            uuid = EXCLUDED.uuid,
+            blurhash = EXCLUDED.blurhash,
+            extra_exts = EXCLUDED.extra_exts,
+            hash = EXCLUDED.hash,
+            width = EXCLUDED.width,
+            height = EXCLUDED.height,
+            crop_top = EXCLUDED.crop_top,
+            crop_left = EXCLUDED.crop_left,
+            verified = FALSE
+    ), updated_person AS (
+        UPDATE person
+        SET
+            last_event_time = now(),
+            last_event_name = 'added-photo',
+            last_event_data = jsonb_build_object(
+                'added_photo_uuid', %(uuid)s,
+                'added_photo_blurhash', %(blurhash)s,
+                'added_photo_extra_exts', %(extra_exts)s::TEXT[]
+            )
+        WHERE
+            id = %(person_id)s
+    )
+    SELECT 1
+    """
+
+    async with api_tx() as tx:
+        await tx.execute(q, params)
+        await tx.execute(Q_UPDATE_VERIFICATION_LEVEL, params)
+
+    try:
+        await put_image_in_object_store(uuid, base64_file, crop_size)
+    except:
+        logger.exception('Storing image failed')
+        return '', 500
+
+    return None
+
+
+async def _patch_audio(person_id: int, field_value: object) -> object:
+    base64_audio_file = t.Base64AudioFile.model_validate(field_value)
+
+    uuid = secrets.token_hex(32)
+
+    params = dict(
+        person_id=person_id,
+        uuid=uuid,
+    )
+
+    q = """
+    WITH existing_uuid AS (
+        SELECT
+            uuid
+        FROM
+            audio
+        WHERE
+            person_id = %(person_id)s
+        AND
+            position = -1
+    ), undeleted_audio_insertion AS (
+        INSERT INTO undeleted_audio (
+            uuid
+        )
+        SELECT
+            uuid
+        FROM
+            existing_uuid
+    ), audio_insertion AS (
+        INSERT INTO audio (
+            person_id,
+            position,
+            uuid
+        ) VALUES (
+            %(person_id)s,
+            -1,
+            %(uuid)s
+        ) ON CONFLICT (person_id, position) DO UPDATE SET
+            uuid = EXCLUDED.uuid
+    ), updated_person AS (
+        UPDATE person
+        SET
+            last_event_time = now(),
+            last_event_name = 'added-voice-bio',
+            last_event_data = jsonb_build_object(
+                'added_audio_uuid', %(uuid)s
+            )
+        WHERE
+            id = %(person_id)s
+    )
+    SELECT 1
+    """
+
+    async with api_tx() as tx:
+        await tx.execute(q, params)
+
+    try:
+        await put_audio_in_object_store(
+            uuid=uuid,
+            audio_file_bytes=base64_audio_file.transcoded,
+        )
+    except:
+        logger.exception('Storing audio failed')
+        return '', 500
+
+    return None
+
+
+async def _patch_photo_assignments(
+        person_id: int, photo_assignments: Mapping[int, int]) -> None:
+    case_sql = '\n'.join(
+        f'WHEN position = {int(k)} THEN {int(v)}'
+        for k, v in photo_assignments.items()
+    )
+
+    params = dict(person_id=person_id)
+
+    # We set the positions to negative indexes first, to avoid violating
+    # uniqueness constraints
+    q1 = f"""
+    UPDATE
+        photo
+    SET
+        position = - (CASE {case_sql} ELSE position END)
+    WHERE
+        person_id = %(person_id)s
+    """
+
+    q2 = """
+    UPDATE
+        photo
+    SET
+        position = ABS(position)
+    WHERE
+        person_id = %(person_id)s
+    """
+
+    async with api_tx() as tx:
+        await tx.execute(q1, params)
+        await tx.execute(q2, params)
+
+
+async def _patch_name(person_id: int, field_value: object) -> object:
+    if not await _has_gold(person_id=person_id):
+        return 'Requires gold', 403
+
+    params = dict(person_id=person_id, field_value=field_value)
+
+    async with api_tx() as tx:
+        await tx.execute(
+            "UPDATE person SET name = %(field_value)s WHERE id = %(person_id)s",
+            params,
+        )
+        return await assign_url_slug(tx, person_id)
+
+
 async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> object:
     if not s.person_id:
         return 'Not authorized', 400
@@ -136,499 +496,60 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
     [field_name] = req.__pydantic_fields_set__
 
     await reject_rude_or_banned(field_name, req)
-    field_value: object
+
     if field_name == 'photo_assignments':
         if req.photo_assignments is None:
             raise ValueError('Field photo_assignments must not be None')
-        field_value = req.photo_assignments.root
-    else:
-        field_value = req.dict()[field_name]
+        await _patch_photo_assignments(
+            s.person_id, req.photo_assignments.root)
+        return None
 
+    field_value: object = req.dict()[field_name]
     if field_value is None and field_name in t.PATCH_PROFILE_INFO_LOOKUP_BASICS:
         field_value = 'Unanswered'
+
+    if field_name == 'base64_file':
+        return await _patch_photo(s.person_id, field_value)
+    if field_name == 'base64_audio_file':
+        return await _patch_audio(s.person_id, field_value)
+    if field_name == 'name':
+        return await _patch_name(s.person_id, field_value)
+    if field_name == 'about':
+        await _patch_profile_info_about(
+            s.person_id,
+            _str_value(field_value, field_name),
+        )
+        return None
+
+    field = _PROFILE_FIELDS.get(field_name)
+    if field is None:
+        return f'Unhandled field name {field_name}', 500
+
+    if field.requires_gold and not await _has_gold(person_id=s.person_id):
+        return 'Requires gold', 403
 
     params = dict(
         person_id=s.person_id,
         field_value=field_value,
     )
 
-    q1 = None
-    q2 = None
-
-    uuid = None
-    base64_file = None
-    crop_size = None
-
-    base64_audio_file = None
-
-    if field_name == 'base64_file':
-        base64_file = t.Base64File.model_validate(field_value)
-
-        crop_size = CropSize(
-                top=base64_file.top,
-                left=base64_file.left)
-        uuid = secrets.token_hex(32)
-        blurhash_ = compute_blurhash(base64_file.image, crop_size=crop_size)
-        extra_exts = ['gif'] if base64_file.image.format == 'GIF' else []
-        geometry = photo_geometry(
-            *orient_image(base64_file.image).size,
-            crop_size,
-        )
-
-        params = dict(
-            person_id=s.person_id,
-            position=base64_file.position,
-            uuid=uuid,
-            blurhash=blurhash_,
-            extra_exts=extra_exts,
-            hash=base64_file.md5_hash,
-            **photo_geometry_params(geometry),
-        )
-
-        q1 = """
-        WITH existing_uuid AS (
-            SELECT
-                uuid
-            FROM
-                photo
-            WHERE
-                person_id = %(person_id)s
-            AND
-                position = %(position)s
-        ), undeleted_photo_insertion AS (
-            INSERT INTO undeleted_photo (
-                uuid
-            )
-            SELECT
-                uuid
-            FROM
-                existing_uuid
-        ), photo_insertion AS (
-            INSERT INTO photo (
-                person_id,
-                position,
-                uuid,
-                blurhash,
-                extra_exts,
-                hash,
-                width,
-                height,
-                crop_top,
-                crop_left
-            ) VALUES (
-                %(person_id)s,
-                %(position)s,
-                %(uuid)s,
-                %(blurhash)s,
-                %(extra_exts)s,
-                %(hash)s,
-                %(width)s,
-                %(height)s,
-                %(crop_top)s,
-                %(crop_left)s
-            ) ON CONFLICT (person_id, position) DO UPDATE SET
-                uuid = EXCLUDED.uuid,
-                blurhash = EXCLUDED.blurhash,
-                extra_exts = EXCLUDED.extra_exts,
-                hash = EXCLUDED.hash,
-                width = EXCLUDED.width,
-                height = EXCLUDED.height,
-                crop_top = EXCLUDED.crop_top,
-                crop_left = EXCLUDED.crop_left,
-                verified = FALSE
-        ), updated_person AS (
-            UPDATE person
-            SET
-                last_event_time = now(),
-                last_event_name = 'added-photo',
-                last_event_data = jsonb_build_object(
-                    'added_photo_uuid', %(uuid)s,
-                    'added_photo_blurhash', %(blurhash)s,
-                    'added_photo_extra_exts', %(extra_exts)s::TEXT[]
-                )
-            WHERE
-                id = %(person_id)s
-        )
-        SELECT 1
-        """
-
-        q2 = Q_UPDATE_VERIFICATION_LEVEL
-    elif field_name == 'base64_audio_file':
-        base64_audio_file = t.Base64AudioFile.model_validate(field_value)
-
-        uuid = secrets.token_hex(32)
-
-        params = dict(
-            person_id=s.person_id,
-            uuid=uuid,
-        )
-
-        q1 = """
-        WITH existing_uuid AS (
-            SELECT
-                uuid
-            FROM
-                audio
-            WHERE
-                person_id = %(person_id)s
-            AND
-                position = -1
-        ), undeleted_audio_insertion AS (
-            INSERT INTO undeleted_audio (
-                uuid
-            )
-            SELECT
-                uuid
-            FROM
-                existing_uuid
-        ), audio_insertion AS (
-            INSERT INTO audio (
-                person_id,
-                position,
-                uuid
-            ) VALUES (
-                %(person_id)s,
-                -1,
-                %(uuid)s
-            ) ON CONFLICT (person_id, position) DO UPDATE SET
-                uuid = EXCLUDED.uuid
-        ), updated_person AS (
-            UPDATE person
-            SET
-                last_event_time = now(),
-                last_event_name = 'added-voice-bio',
-                last_event_data = jsonb_build_object(
-                    'added_audio_uuid', %(uuid)s
-                )
-            WHERE
-                id = %(person_id)s
-        )
-        SELECT 1
-        """
-    elif field_name == 'photo_assignments':
-        if req.photo_assignments is None:
-            raise ValueError('Field photo_assignments must not be None')
-        photo_assignments = req.photo_assignments.root
-        case_sql = '\n'.join(
-            f'WHEN position = {int(k)} THEN {int(v)}'
-            for k, v in photo_assignments.items()
-        )
-
-        # We set the positions to negative indexes first, to avoid violating
-        # uniqueness constraints
-        q1 = f"""
-        UPDATE
-            photo
-        SET
-            position = - (CASE {case_sql} ELSE position END)
-        WHERE
-            person_id = %(person_id)s
-        """
-
-        q2 = """
-        UPDATE
-            photo
-        SET
-            position = ABS(position)
-        WHERE
-            person_id = %(person_id)s
-        """
-    elif field_name == 'name':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
-        async with api_tx() as tx:
-            await tx.execute(
-                "UPDATE person SET name = %(field_value)s WHERE id = %(person_id)s",
-                params,
-            )
-            slug = await assign_url_slug(tx, s.person_id)
-
-        return slug
-    elif field_name == 'about':
-        await _patch_profile_info_about(
-            s.person_id,
-            _str_value(field_value, field_name),
-        )
-        return None
-    elif field_name == 'gender':
-        q1 = """
-        UPDATE person
-        SET gender_id = gender.id, verified_gender = false
-        FROM gender
-        WHERE person.id = %(person_id)s
-        AND gender.name = %(field_value)s
-        AND person.gender_id <> gender.id
-        """
-
-        q2 = Q_UPDATE_VERIFICATION_LEVEL
-    elif field_name == 'orientation':
-        q1 = """
-        UPDATE person SET orientation_id = orientation.id
-        FROM orientation
-        WHERE person.id = %(person_id)s
-        AND orientation.name = %(field_value)s
-        """
-    elif field_name == 'ethnicity':
-        q1 = """
-        UPDATE person
-        SET ethnicity_id = ethnicity.id, verified_ethnicity = false
-        FROM ethnicity
-        WHERE person.id = %(person_id)s
-        AND ethnicity.name = %(field_value)s
-        AND person.ethnicity_id <> ethnicity.id
-        """
-
-        q2 = Q_UPDATE_VERIFICATION_LEVEL
-    elif field_name == 'location':
-        q1 = """
-        UPDATE person
-        SET
-            coordinates
-                = location.coordinates,
-
-            verification_required
-                = location.verification_required OR person.verification_required,
-
-            location_short_friendly
-                = location.short_friendly,
-
-            location_long_friendly
-                = location.long_friendly,
-
-            location_country
-                = location.country
-        FROM location
-        WHERE person.id = %(person_id)s
-        AND long_friendly = %(field_value)s
-        """
-    elif field_name == 'occupation':
-        q1 = """
-        UPDATE person SET occupation = %(field_value)s
-        WHERE person.id = %(person_id)s
-        """
-    elif field_name == 'education':
-        q1 = """
-        UPDATE person SET education = %(field_value)s
-        WHERE person.id = %(person_id)s
-        """
-    elif field_name == 'height':
-        q1 = """
-        UPDATE person SET height_cm = %(field_value)s
-        WHERE person.id = %(person_id)s
-        """
-    elif field_name == 'looking_for':
-        q1 = """
-        UPDATE person SET looking_for_id = looking_for.id
-        FROM looking_for
-        WHERE person.id = %(person_id)s
-        AND looking_for.name = %(field_value)s
-        """
-    elif field_name == 'smoking':
-        q1 = """
-        UPDATE person SET smoking_id = yes_no_optional.id
-        FROM yes_no_optional
-        WHERE person.id = %(person_id)s
-        AND yes_no_optional.name = %(field_value)s
-        """
-    elif field_name == 'drinking':
-        q1 = """
-        UPDATE person SET drinking_id = frequency.id
-        FROM frequency
-        WHERE person.id = %(person_id)s
-        AND frequency.name = %(field_value)s
-        """
-    elif field_name == 'drugs':
-        q1 = """
-        UPDATE person SET drugs_id = yes_no_optional.id
-        FROM yes_no_optional
-        WHERE person.id = %(person_id)s
-        AND yes_no_optional.name = %(field_value)s
-        """
-    elif field_name == 'long_distance':
-        q1 = """
-        UPDATE person SET long_distance_id = yes_no_optional.id
-        FROM yes_no_optional
-        WHERE person.id = %(person_id)s
-        AND yes_no_optional.name = %(field_value)s
-        """
-    elif field_name == 'relationship_status':
-        q1 = """
-        UPDATE person SET relationship_status_id = relationship_status.id
-        FROM relationship_status
-        WHERE person.id = %(person_id)s
-        AND relationship_status.name = %(field_value)s
-        """
-    elif field_name == 'has_kids':
-        q1 = """
-        UPDATE person SET has_kids_id = yes_no_maybe.id
-        FROM yes_no_maybe
-        WHERE person.id = %(person_id)s
-        AND yes_no_maybe.name = %(field_value)s
-        """
-    elif field_name == 'wants_kids':
-        q1 = """
-        UPDATE person SET wants_kids_id = yes_no_maybe.id
-        FROM yes_no_maybe
-        WHERE person.id = %(person_id)s
-        AND yes_no_maybe.name = %(field_value)s
-        """
-    elif field_name == 'exercise':
-        q1 = """
-        UPDATE person SET exercise_id = frequency.id
-        FROM frequency
-        WHERE person.id = %(person_id)s
-        AND frequency.name = %(field_value)s
-        """
-    elif field_name == 'religion':
-        q1 = """
-        UPDATE person SET religion_id = religion.id
-        FROM religion
-        WHERE person.id = %(person_id)s
-        AND religion.name = %(field_value)s
-        """
-    elif field_name == 'star_sign':
-        q1 = """
-        UPDATE person SET star_sign_id = star_sign.id
-        FROM star_sign
-        WHERE person.id = %(person_id)s
-        AND star_sign.name = %(field_value)s
-        """
-    elif field_name == 'units':
-        q1 = """
-        UPDATE person SET unit_id = unit.id
-        FROM unit
-        WHERE person.id = %(person_id)s
-        AND unit.name = %(field_value)s
-        """
-    elif field_name == 'chats':
-        q1 = """
-        UPDATE person SET chats_notification = immediacy.id
-        FROM immediacy
-        WHERE person.id = %(person_id)s
-        AND immediacy.name = %(field_value)s
-        """
-    elif field_name == 'intros':
-        q1 = """
-        UPDATE person SET intros_notification = immediacy.id
-        FROM immediacy
-        WHERE person.id = %(person_id)s
-        AND immediacy.name = %(field_value)s
-        """
-    elif field_name == 'visitors':
-        q1 = """
-        UPDATE person SET visitors_notification = immediacy.id
-        FROM immediacy
-        WHERE person.id = %(person_id)s
-        AND immediacy.name = %(field_value)s
-        """
-    elif field_name == 'verification_level':
-        q1 = """
-        UPDATE person
-        SET privacy_verification_level_id = verification_level.id
-        FROM verification_level
-        WHERE person.id = %(person_id)s AND
-        verification_level.name = %(field_value)s
-        """
-    elif field_name == 'show_my_location':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
-        q1 = """
-        UPDATE person
-        SET show_my_location_id = yes_country_only_no.id
-        FROM yes_country_only_no
-        WHERE person.id = %(person_id)s
-        AND yes_country_only_no.name = %(field_value)s
-        """
-    elif field_name == 'show_my_age':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
-        q1 = """
-        UPDATE person
-        SET show_my_age = (
-            CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-        WHERE id = %(person_id)s
-        """
-    elif field_name == 'show_my_looking_for':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
-        q1 = """
-        UPDATE person
-        SET show_my_looking_for = (
-            CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-        WHERE id = %(person_id)s
-        """
-    elif field_name == 'hide_me_from_strangers':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
-        q1 = """
-        UPDATE person
-        SET hide_me_from_strangers = (
-            CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-        WHERE id = %(person_id)s
-        """
-    elif field_name == 'browse_invisibly':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
-        q1 = """
-        UPDATE person
-        SET browse_invisibly = (
-            CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-        WHERE id = %(person_id)s
-        """
-    elif field_name == 'show_my_online_status':
-        q1 = """
-        UPDATE person
-        SET show_my_online_status = (
-            CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-        WHERE id = %(person_id)s
-        """
-    elif field_name == 'public_profile':
-        q1 = """
-        UPDATE person
-        SET public_profile = (
-            CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-        WHERE id = %(person_id)s
-        """
-    elif field_name == 'theme':
-        if not await _has_gold(person_id=s.person_id):
-            return 'Requires gold', 403
-
+    if field_name == 'theme':
         try:
             theme = t.Theme.model_validate(field_value)
-            title_color = theme.title_color
-            body_color = theme.body_color
-            background_color = theme.background_color
-
             params.update(
                 dict(
-                    title_color=title_color,
-                    body_color=body_color,
-                    background_color=background_color,
+                    title_color=theme.title_color,
+                    body_color=theme.body_color,
+                    background_color=theme.background_color,
                 )
             )
         except:
             return f'Invalid colors', 400
 
-        q1 = """
-        UPDATE person
-        SET
-            title_color = %(title_color)s,
-            body_color = %(body_color)s,
-            background_color = %(background_color)s
-        WHERE id = %(person_id)s
-        """
-    else:
-        return f'Unhandled field name {field_name}', 500
-
     async with api_tx() as tx:
-        if q1: await tx.execute(q1, params)
-        if q2: await tx.execute(q2, params)
+        await tx.execute(field.q1, params)
+        if field.q2:
+            await tx.execute(field.q2, params)
 
     if field_name == 'show_my_online_status' and s.person_uuid is not None:
         await redis_publish_online(
@@ -636,22 +557,5 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
             username=s.person_uuid,
             visible=field_value == 'Yes',
         )
-
-    if uuid and base64_file and crop_size:
-        try:
-            await put_image_in_object_store(uuid, base64_file, crop_size)
-        except:
-            logger.exception('Storing image failed')
-            return '', 500
-
-    if uuid and base64_audio_file:
-        try:
-            await put_audio_in_object_store(
-                uuid=uuid,
-                audio_file_bytes=base64_audio_file.transcoded,
-            )
-        except:
-            logger.exception('Storing audio failed')
-            return '', 500
 
     return None

--- a/backend/service/api/person/profileinfo/__init__.py
+++ b/backend/service/api/person/profileinfo/__init__.py
@@ -212,6 +212,108 @@ SET
 WHERE id = %(person_id)s
 """
 
+@dataclass(frozen=True)
+class _ProfileField:
+    q1: str
+    q2: str | None = None
+    requires_gold: bool = False
+
+def _person_lookup_q(column: str, table: str) -> str:
+    return f"""
+    UPDATE person SET {column} = {table}.id
+    FROM {table}
+    WHERE person.id = %(person_id)s
+    AND {table}.name = %(field_value)s
+    """
+
+
+def _person_verified_lookup_q(column: str, table: str,
+                              verified_column: str) -> str:
+    return f"""
+    UPDATE person
+    SET {column} = {table}.id, {verified_column} = false
+    FROM {table}
+    WHERE person.id = %(person_id)s
+    AND {table}.name = %(field_value)s
+    AND person.{column} <> {table}.id
+    """
+
+
+def _person_yes_no_q(column: str) -> str:
+    return f"""
+    UPDATE person
+    SET {column} = (
+        CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
+    WHERE id = %(person_id)s
+    """
+
+
+def _person_value_q(column: str) -> str:
+    return f"""
+    UPDATE person SET {column} = %(field_value)s
+    WHERE person.id = %(person_id)s
+    """
+
+_PROFILE_FIELDS = {
+    'gender': _ProfileField(
+        q1=_person_verified_lookup_q('gender_id', 'gender', 'verified_gender'),
+        q2=Q_UPDATE_VERIFICATION_LEVEL,
+    ),
+    'orientation': _ProfileField(
+        q1=_person_lookup_q('orientation_id', 'orientation')),
+    'ethnicity': _ProfileField(
+        q1=_person_verified_lookup_q(
+            'ethnicity_id', 'ethnicity', 'verified_ethnicity'),
+        q2=Q_UPDATE_VERIFICATION_LEVEL,
+    ),
+    'location': _ProfileField(q1=Q_PATCH_LOCATION),
+    'occupation': _ProfileField(q1=_person_value_q('occupation')),
+    'education': _ProfileField(q1=_person_value_q('education')),
+    'height': _ProfileField(q1=_person_value_q('height_cm')),
+    'looking_for': _ProfileField(
+        q1=_person_lookup_q('looking_for_id', 'looking_for')),
+    'smoking': _ProfileField(
+        q1=_person_lookup_q('smoking_id', 'yes_no_optional')),
+    'drinking': _ProfileField(q1=_person_lookup_q('drinking_id', 'frequency')),
+    'drugs': _ProfileField(q1=_person_lookup_q('drugs_id', 'yes_no_optional')),
+    'long_distance': _ProfileField(
+        q1=_person_lookup_q('long_distance_id', 'yes_no_optional')),
+    'relationship_status': _ProfileField(
+        q1=_person_lookup_q('relationship_status_id', 'relationship_status')),
+    'has_kids': _ProfileField(
+        q1=_person_lookup_q('has_kids_id', 'yes_no_maybe')),
+    'wants_kids': _ProfileField(
+        q1=_person_lookup_q('wants_kids_id', 'yes_no_maybe')),
+    'exercise': _ProfileField(q1=_person_lookup_q('exercise_id', 'frequency')),
+    'religion': _ProfileField(q1=_person_lookup_q('religion_id', 'religion')),
+    'star_sign': _ProfileField(q1=_person_lookup_q('star_sign_id', 'star_sign')),
+    'units': _ProfileField(q1=_person_lookup_q('unit_id', 'unit')),
+    'chats': _ProfileField(
+        q1=_person_lookup_q('chats_notification', 'immediacy')),
+    'intros': _ProfileField(
+        q1=_person_lookup_q('intros_notification', 'immediacy')),
+    'visitors': _ProfileField(
+        q1=_person_lookup_q('visitors_notification', 'immediacy')),
+    'verification_level': _ProfileField(
+        q1=_person_lookup_q(
+            'privacy_verification_level_id', 'verification_level')),
+    'show_my_location': _ProfileField(
+        q1=_person_lookup_q('show_my_location_id', 'yes_country_only_no'),
+        requires_gold=True,
+    ),
+    'show_my_age': _ProfileField(
+        q1=_person_yes_no_q('show_my_age'), requires_gold=True),
+    'show_my_looking_for': _ProfileField(
+        q1=_person_yes_no_q('show_my_looking_for'), requires_gold=True),
+    'hide_me_from_strangers': _ProfileField(
+        q1=_person_yes_no_q('hide_me_from_strangers'), requires_gold=True),
+    'browse_invisibly': _ProfileField(
+        q1=_person_yes_no_q('browse_invisibly'), requires_gold=True),
+    'show_my_online_status': _ProfileField(
+        q1=_person_yes_no_q('show_my_online_status')),
+    'public_profile': _ProfileField(q1=_person_yes_no_q('public_profile')),
+    'theme': _ProfileField(q1=Q_PATCH_THEME, requires_gold=True),
+}
 
 async def _has_gold(person_id: int) -> bool:
     async with api_tx() as tx:
@@ -274,111 +376,6 @@ async def _patch_profile_info_about(
         )
 
         await tx.execute(Q_PATCH_ABOUT, update_params)
-
-def _person_lookup_q(column: str, table: str) -> str:
-    return f"""
-    UPDATE person SET {column} = {table}.id
-    FROM {table}
-    WHERE person.id = %(person_id)s
-    AND {table}.name = %(field_value)s
-    """
-
-
-def _person_verified_lookup_q(column: str, table: str,
-                              verified_column: str) -> str:
-    return f"""
-    UPDATE person
-    SET {column} = {table}.id, {verified_column} = false
-    FROM {table}
-    WHERE person.id = %(person_id)s
-    AND {table}.name = %(field_value)s
-    AND person.{column} <> {table}.id
-    """
-
-
-def _person_yes_no_q(column: str) -> str:
-    return f"""
-    UPDATE person
-    SET {column} = (
-        CASE WHEN %(field_value)s = 'Yes' THEN TRUE ELSE FALSE END)
-    WHERE id = %(person_id)s
-    """
-
-
-def _person_value_q(column: str) -> str:
-    return f"""
-    UPDATE person SET {column} = %(field_value)s
-    WHERE person.id = %(person_id)s
-    """
-
-
-@dataclass(frozen=True)
-class _ProfileField:
-    q1: str
-    q2: str | None = None
-    requires_gold: bool = False
-
-
-_PROFILE_FIELDS = {
-    'gender': _ProfileField(
-        q1=_person_verified_lookup_q('gender_id', 'gender', 'verified_gender'),
-        q2=Q_UPDATE_VERIFICATION_LEVEL,
-    ),
-    'orientation': _ProfileField(
-        q1=_person_lookup_q('orientation_id', 'orientation')),
-    'ethnicity': _ProfileField(
-        q1=_person_verified_lookup_q(
-            'ethnicity_id', 'ethnicity', 'verified_ethnicity'),
-        q2=Q_UPDATE_VERIFICATION_LEVEL,
-    ),
-    'location': _ProfileField(q1=Q_PATCH_LOCATION),
-    'occupation': _ProfileField(q1=_person_value_q('occupation')),
-    'education': _ProfileField(q1=_person_value_q('education')),
-    'height': _ProfileField(q1=_person_value_q('height_cm')),
-    'looking_for': _ProfileField(
-        q1=_person_lookup_q('looking_for_id', 'looking_for')),
-    'smoking': _ProfileField(
-        q1=_person_lookup_q('smoking_id', 'yes_no_optional')),
-    'drinking': _ProfileField(q1=_person_lookup_q('drinking_id', 'frequency')),
-    'drugs': _ProfileField(q1=_person_lookup_q('drugs_id', 'yes_no_optional')),
-    'long_distance': _ProfileField(
-        q1=_person_lookup_q('long_distance_id', 'yes_no_optional')),
-    'relationship_status': _ProfileField(
-        q1=_person_lookup_q('relationship_status_id', 'relationship_status')),
-    'has_kids': _ProfileField(
-        q1=_person_lookup_q('has_kids_id', 'yes_no_maybe')),
-    'wants_kids': _ProfileField(
-        q1=_person_lookup_q('wants_kids_id', 'yes_no_maybe')),
-    'exercise': _ProfileField(q1=_person_lookup_q('exercise_id', 'frequency')),
-    'religion': _ProfileField(q1=_person_lookup_q('religion_id', 'religion')),
-    'star_sign': _ProfileField(q1=_person_lookup_q('star_sign_id', 'star_sign')),
-    'units': _ProfileField(q1=_person_lookup_q('unit_id', 'unit')),
-    'chats': _ProfileField(
-        q1=_person_lookup_q('chats_notification', 'immediacy')),
-    'intros': _ProfileField(
-        q1=_person_lookup_q('intros_notification', 'immediacy')),
-    'visitors': _ProfileField(
-        q1=_person_lookup_q('visitors_notification', 'immediacy')),
-    'verification_level': _ProfileField(
-        q1=_person_lookup_q(
-            'privacy_verification_level_id', 'verification_level')),
-    'show_my_location': _ProfileField(
-        q1=_person_lookup_q('show_my_location_id', 'yes_country_only_no'),
-        requires_gold=True,
-    ),
-    'show_my_age': _ProfileField(
-        q1=_person_yes_no_q('show_my_age'), requires_gold=True),
-    'show_my_looking_for': _ProfileField(
-        q1=_person_yes_no_q('show_my_looking_for'), requires_gold=True),
-    'hide_me_from_strangers': _ProfileField(
-        q1=_person_yes_no_q('hide_me_from_strangers'), requires_gold=True),
-    'browse_invisibly': _ProfileField(
-        q1=_person_yes_no_q('browse_invisibly'), requires_gold=True),
-    'show_my_online_status': _ProfileField(
-        q1=_person_yes_no_q('show_my_online_status')),
-    'public_profile': _ProfileField(q1=_person_yes_no_q('public_profile')),
-    'theme': _ProfileField(q1=Q_PATCH_THEME, requires_gold=True),
-}
 
 
 async def _patch_photo(person_id: int, field_value: object) -> object:

--- a/backend/service/api/person/profileinfo/__init__.py
+++ b/backend/service/api/person/profileinfo/__init__.py
@@ -26,6 +26,193 @@ from serviceshared.database import api_tx
 
 logger = logging.getLogger(__name__)
 
+
+Q_PATCH_ABOUT = """
+WITH updated_person AS (
+    UPDATE person
+    SET
+        about = %(new_about)s::TEXT,
+
+        last_event_time =
+            CASE
+                WHEN %(added_text)s::TEXT IS NULL
+                THEN sign_up_time
+                ELSE now()
+            END,
+
+        last_event_name =
+            CASE
+                WHEN %(added_text)s::TEXT IS NULL
+                THEN 'joined'::person_event
+                ELSE 'updated-bio'::person_event
+            END,
+
+        last_event_data =
+            CASE
+                WHEN %(added_text)s::TEXT IS NULL
+                THEN
+                    '{}'::JSONB
+                ELSE
+                    jsonb_build_object(
+                        'added_text', %(added_text)s::TEXT,
+                        'body_color', body_color,
+                        'background_color', background_color
+                    )
+            END
+    WHERE
+        id = %(person_id)s
+), updated_unmoderated_person AS (
+    INSERT INTO
+        unmoderated_person (person_id, trait)
+    VALUES
+        (%(person_id)s, 'about')
+    ON CONFLICT DO NOTHING
+)
+SELECT 1
+"""
+
+Q_PATCH_PHOTO = """
+WITH existing_uuid AS (
+    SELECT
+        uuid
+    FROM
+        photo
+    WHERE
+        person_id = %(person_id)s
+    AND
+        position = %(position)s
+), undeleted_photo_insertion AS (
+    INSERT INTO undeleted_photo (
+        uuid
+    )
+    SELECT
+        uuid
+    FROM
+        existing_uuid
+), photo_insertion AS (
+    INSERT INTO photo (
+        person_id,
+        position,
+        uuid,
+        blurhash,
+        extra_exts,
+        hash,
+        width,
+        height,
+        crop_top,
+        crop_left
+    ) VALUES (
+        %(person_id)s,
+        %(position)s,
+        %(uuid)s,
+        %(blurhash)s,
+        %(extra_exts)s,
+        %(hash)s,
+        %(width)s,
+        %(height)s,
+        %(crop_top)s,
+        %(crop_left)s
+    ) ON CONFLICT (person_id, position) DO UPDATE SET
+        uuid = EXCLUDED.uuid,
+        blurhash = EXCLUDED.blurhash,
+        extra_exts = EXCLUDED.extra_exts,
+        hash = EXCLUDED.hash,
+        width = EXCLUDED.width,
+        height = EXCLUDED.height,
+        crop_top = EXCLUDED.crop_top,
+        crop_left = EXCLUDED.crop_left,
+        verified = FALSE
+), updated_person AS (
+    UPDATE person
+    SET
+        last_event_time = now(),
+        last_event_name = 'added-photo',
+        last_event_data = jsonb_build_object(
+            'added_photo_uuid', %(uuid)s,
+            'added_photo_blurhash', %(blurhash)s,
+            'added_photo_extra_exts', %(extra_exts)s::TEXT[]
+        )
+    WHERE
+        id = %(person_id)s
+)
+SELECT 1
+"""
+
+Q_PATCH_AUDIO = """
+WITH existing_uuid AS (
+    SELECT
+        uuid
+    FROM
+        audio
+    WHERE
+        person_id = %(person_id)s
+    AND
+        position = -1
+), undeleted_audio_insertion AS (
+    INSERT INTO undeleted_audio (
+        uuid
+    )
+    SELECT
+        uuid
+    FROM
+        existing_uuid
+), audio_insertion AS (
+    INSERT INTO audio (
+        person_id,
+        position,
+        uuid
+    ) VALUES (
+        %(person_id)s,
+        -1,
+        %(uuid)s
+    ) ON CONFLICT (person_id, position) DO UPDATE SET
+        uuid = EXCLUDED.uuid
+), updated_person AS (
+    UPDATE person
+    SET
+        last_event_time = now(),
+        last_event_name = 'added-voice-bio',
+        last_event_data = jsonb_build_object(
+            'added_audio_uuid', %(uuid)s
+        )
+    WHERE
+        id = %(person_id)s
+)
+SELECT 1
+"""
+
+Q_PATCH_LOCATION = """
+UPDATE person
+SET
+    coordinates
+        = location.coordinates,
+
+    verification_required
+        = location.verification_required OR person.verification_required,
+
+    location_short_friendly
+        = location.short_friendly,
+
+    location_long_friendly
+        = location.long_friendly,
+
+    location_country
+        = location.country
+FROM location
+WHERE person.id = %(person_id)s
+AND long_friendly = %(field_value)s
+"""
+
+Q_PATCH_THEME = """
+UPDATE person
+SET
+    title_color = %(title_color)s,
+    body_color = %(body_color)s,
+    background_color = %(background_color)s
+WHERE id = %(person_id)s
+"""
+
+
 async def _has_gold(person_id: int) -> bool:
     async with api_tx() as tx:
         row = await tx.require_one(Q_HAS_GOLD, dict(person_id=person_id))
@@ -64,56 +251,13 @@ async def delete_profile_info(req: t.DeleteProfileInfo, s: t.SessionInfo) -> Non
         async with api_tx() as tx:
             await tx.executemany(Q_DELETE_PROFILE_INFO_AUDIO, audio_files_params)
 
+
 async def _patch_profile_info_about(
     person_id: int,
     new_about: str,
 ) -> None:
     select = """
     SELECT about AS old_about FROM person WHERE id = %(person_id)s
-    """
-
-    update = """
-    WITH updated_person AS (
-        UPDATE person
-        SET
-            about = %(new_about)s::TEXT,
-
-            last_event_time =
-                CASE
-                    WHEN %(added_text)s::TEXT IS NULL
-                    THEN sign_up_time
-                    ELSE now()
-                END,
-
-            last_event_name =
-                CASE
-                    WHEN %(added_text)s::TEXT IS NULL
-                    THEN 'joined'::person_event
-                    ELSE 'updated-bio'::person_event
-                END,
-
-            last_event_data =
-                CASE
-                    WHEN %(added_text)s::TEXT IS NULL
-                    THEN
-                        '{}'::JSONB
-                    ELSE
-                        jsonb_build_object(
-                            'added_text', %(added_text)s::TEXT,
-                            'body_color', body_color,
-                            'background_color', background_color
-                        )
-                END
-        WHERE
-            id = %(person_id)s
-    ), updated_unmoderated_person AS (
-        INSERT INTO
-            unmoderated_person (person_id, trait)
-        VALUES
-            (%(person_id)s, 'about')
-        ON CONFLICT DO NOTHING
-    )
-    SELECT 1
     """
 
     async with api_tx() as tx:
@@ -129,7 +273,7 @@ async def _patch_profile_info_about(
             added_text=diff_addition_with_context(old=old_about, new=new_about),
         )
 
-        await tx.execute(update, update_params)
+        await tx.execute(Q_PATCH_ABOUT, update_params)
 
 def _person_lookup_q(column: str, table: str) -> str:
     return f"""
@@ -166,38 +310,6 @@ def _person_value_q(column: str) -> str:
     UPDATE person SET {column} = %(field_value)s
     WHERE person.id = %(person_id)s
     """
-
-
-Q_PATCH_LOCATION = """
-UPDATE person
-SET
-    coordinates
-        = location.coordinates,
-
-    verification_required
-        = location.verification_required OR person.verification_required,
-
-    location_short_friendly
-        = location.short_friendly,
-
-    location_long_friendly
-        = location.long_friendly,
-
-    location_country
-        = location.country
-FROM location
-WHERE person.id = %(person_id)s
-AND long_friendly = %(field_value)s
-"""
-
-Q_PATCH_THEME = """
-UPDATE person
-SET
-    title_color = %(title_color)s,
-    body_color = %(body_color)s,
-    background_color = %(background_color)s
-WHERE id = %(person_id)s
-"""
 
 
 @dataclass(frozen=True)
@@ -293,75 +405,8 @@ async def _patch_photo(person_id: int, field_value: object) -> object:
         **photo_geometry_params(geometry),
     )
 
-    q = """
-    WITH existing_uuid AS (
-        SELECT
-            uuid
-        FROM
-            photo
-        WHERE
-            person_id = %(person_id)s
-        AND
-            position = %(position)s
-    ), undeleted_photo_insertion AS (
-        INSERT INTO undeleted_photo (
-            uuid
-        )
-        SELECT
-            uuid
-        FROM
-            existing_uuid
-    ), photo_insertion AS (
-        INSERT INTO photo (
-            person_id,
-            position,
-            uuid,
-            blurhash,
-            extra_exts,
-            hash,
-            width,
-            height,
-            crop_top,
-            crop_left
-        ) VALUES (
-            %(person_id)s,
-            %(position)s,
-            %(uuid)s,
-            %(blurhash)s,
-            %(extra_exts)s,
-            %(hash)s,
-            %(width)s,
-            %(height)s,
-            %(crop_top)s,
-            %(crop_left)s
-        ) ON CONFLICT (person_id, position) DO UPDATE SET
-            uuid = EXCLUDED.uuid,
-            blurhash = EXCLUDED.blurhash,
-            extra_exts = EXCLUDED.extra_exts,
-            hash = EXCLUDED.hash,
-            width = EXCLUDED.width,
-            height = EXCLUDED.height,
-            crop_top = EXCLUDED.crop_top,
-            crop_left = EXCLUDED.crop_left,
-            verified = FALSE
-    ), updated_person AS (
-        UPDATE person
-        SET
-            last_event_time = now(),
-            last_event_name = 'added-photo',
-            last_event_data = jsonb_build_object(
-                'added_photo_uuid', %(uuid)s,
-                'added_photo_blurhash', %(blurhash)s,
-                'added_photo_extra_exts', %(extra_exts)s::TEXT[]
-            )
-        WHERE
-            id = %(person_id)s
-    )
-    SELECT 1
-    """
-
     async with api_tx() as tx:
-        await tx.execute(q, params)
+        await tx.execute(Q_PATCH_PHOTO, params)
         await tx.execute(Q_UPDATE_VERIFICATION_LEVEL, params)
 
     try:
@@ -383,51 +428,8 @@ async def _patch_audio(person_id: int, field_value: object) -> object:
         uuid=uuid,
     )
 
-    q = """
-    WITH existing_uuid AS (
-        SELECT
-            uuid
-        FROM
-            audio
-        WHERE
-            person_id = %(person_id)s
-        AND
-            position = -1
-    ), undeleted_audio_insertion AS (
-        INSERT INTO undeleted_audio (
-            uuid
-        )
-        SELECT
-            uuid
-        FROM
-            existing_uuid
-    ), audio_insertion AS (
-        INSERT INTO audio (
-            person_id,
-            position,
-            uuid
-        ) VALUES (
-            %(person_id)s,
-            -1,
-            %(uuid)s
-        ) ON CONFLICT (person_id, position) DO UPDATE SET
-            uuid = EXCLUDED.uuid
-    ), updated_person AS (
-        UPDATE person
-        SET
-            last_event_time = now(),
-            last_event_name = 'added-voice-bio',
-            last_event_data = jsonb_build_object(
-                'added_audio_uuid', %(uuid)s
-            )
-        WHERE
-            id = %(person_id)s
-    )
-    SELECT 1
-    """
-
     async with api_tx() as tx:
-        await tx.execute(q, params)
+        await tx.execute(Q_PATCH_AUDIO, params)
 
     try:
         await put_audio_in_object_store(


### PR DESCRIPTION
`patch_profile_info` had grown to five hundred lines: three media pipelines,
two bespoke fields, and thirty near-identical branches building one of three
query shapes, all funnelled through one shared tail.

The media pipelines (photo, audio, photo assignments) and the name field are
their own handlers now, each owning its transaction and its follow-up work.
The mechanical fields become one table mapping a field name to its queries
and whether it requires gold, with the three query shapes generated by
`_person_lookup_q`, `_person_verified_lookup_q` and `_person_yes_no_q`
rather than copied out thirty times.

**No behaviour change.** 31 of the old handler's 36 branches are now table
entries, and each of the 33 queries the table generates is token-identical to
the branch it replaces (whitespace-normalised comparison against the previous
version of the file — I checked all of them mechanically, not by eye). The
remaining five — `about`, `base64_file`, `base64_audio_file`,
`photo_assignments` and `name` — are the ones that were never mechanical;
they keep their own code paths.

Split out of #1518, where this refactor was originally made to give the
matching-model refresh hook somewhere clean to live. It stands on its own and
has nothing to do with the model, so it is easier to review here: that PR is
left with a two-line change to this file instead of an 858-line one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)