### PR TITLE
Disable the kv vector refresh until it fits the CPU budget

### DIFF
--- a/backend/serviceshared/matching/kv.py
+++ b/backend/serviceshared/matching/kv.py
@@ -79,6 +79,7 @@ class _LongerConversationsModel:
         person_id: int,
         changes: Sequence[CapturedChange],
     ) -> None:
+        return
         await refresh.refresh(tx, person_id, changes)
 
 


### PR DESCRIPTION
Kill switch for the post-#1518 CPU climb: `fire` returns before
`refresh.refresh`, so no write recomputes any vector. The counter bumps
and `messaged` writes are plain SQL and keep working; nothing reads
`kv_vector` until #1521, so stale vectors have no user impact.

When re-enabling: any `kv_who_pre`/`kv_look_pre` caches computed since
#1518 deployed will have missed answer changes made while this was off,
so NULL both columns in the same deploy (`UPDATE person SET kv_who_pre =
NULL, kv_look_pre = NULL`) and let the backfill (#1519) rebuild everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)