### PR TITLE
Drop the no-longer-written club_distance column

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -9,12 +9,5 @@
 -- init-api.sql is the source of truth for the current schema; migrations.sql
 -- carries the same change to already-created databases.
 
-
-ALTER TABLE person
-    ADD COLUMN IF NOT EXISTS kv_vector HALFVEC(132) NOT NULL DEFAULT array_full(132, 0);
-
-ALTER TABLE person
-    ADD COLUMN IF NOT EXISTS kv_who_pre INT[],
-    ADD COLUMN IF NOT EXISTS kv_look_pre INT[];
-
-INSERT INTO sort_by (name) VALUES ('Longer conversations') ON CONFLICT (name) DO NOTHING;
+ALTER TABLE search_cache
+    DROP COLUMN IF EXISTS club_distance;


### PR DESCRIPTION
Stacked on #1521, which stops the API reading or writing `search_cache.club_distance`. This drops the column in a later deploy, once no running replica still names it in its INSERT — the same two-step used for the `search_preference_*` tables in #1456. Merge only after #1521 is fully rolled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)