### PR TITLE
Assign the "Longer conversations" default by person ID parity

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -43,7 +43,7 @@ services:
     environment:
       DUO_ENV: dev
 
-      DUO_LONGER_CONVERSATIONS_DEFAULT_SHARE: '0'
+      DUO_LONGER_CONVERSATIONS_DEFAULT_TRIAL: 'false'
 
       # Unit-test discovery runs in this container and imports
       # service.cron, which fails fast without this or an OpenAI key.

--- a/backend/service/api/person/__init__.py
+++ b/backend/service/api/person/__init__.py
@@ -51,7 +51,7 @@ from serviceshared.verification.messages import (
 
 from serviceshared.duoenv.api import (
     ENV as DUO_ENV,
-    LONGER_CONVERSATIONS_DEFAULT_SHARE,
+    LONGER_CONVERSATIONS_DEFAULT_TRIAL,
 )
 from serviceshared.duoenv.shared import R2_ACCT_ID
 
@@ -590,7 +590,7 @@ async def post_finish_onboarding(s: t.SessionInfo) -> object:
         email=s.email,
         normalized_email=normalize_email(s.email),
         pending_club_name=s.pending_club_name,
-        longer_conversations_default_share=LONGER_CONVERSATIONS_DEFAULT_SHARE,
+        longer_conversations_default_trial=LONGER_CONVERSATIONS_DEFAULT_TRIAL,
     )
 
     async with api_tx() as tx:

--- a/backend/service/api/person/sql/__init__.py
+++ b/backend/service/api/person/sql/__init__.py
@@ -514,7 +514,7 @@ WITH onboardee_location AS (
         1
     OFFSET
         1
-), default_sort_by AS MATERIALIZED (
+), default_sort_by AS (
     SELECT
         longer_conversations,
         (
@@ -528,9 +528,12 @@ WITH onboardee_location AS (
         ) AS id
     FROM (
         SELECT
-            random() < %(longer_conversations_default_share)s
+            %(longer_conversations_default_trial)s::BOOLEAN
+                AND MOD(new_person.id, 2) = 0
                 AS longer_conversations
-    ) AS draw
+        FROM
+            new_person
+    ) AS assignment
 ), updated_session AS (
     UPDATE duo_session
     SET person_id = new_person.id

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -1,5 +1,6 @@
 from serviceshared.duoenv.read import (
     csv,
+    flag_with,
     float_with,
     int_with,
     required_str,
@@ -34,5 +35,5 @@ APPLE_ANDROID_REDIRECT_URL = stripped_str('DUO_APPLE_ANDROID_REDIRECT_URL')
 VAPID_SUBJECT = str_with('DUO_VAPID_SUBJECT', 'mailto:support@duolicious.app')
 VAPID_PRIVATE_KEY = str_with('DUO_VAPID_PRIVATE_KEY', '')
 
-LONGER_CONVERSATIONS_DEFAULT_SHARE = \
-    float_with('DUO_LONGER_CONVERSATIONS_DEFAULT_SHARE', 0.1)
+LONGER_CONVERSATIONS_DEFAULT_TRIAL = \
+    flag_with('DUO_LONGER_CONVERSATIONS_DEFAULT_TRIAL', 'true')


### PR DESCRIPTION
Follows #1552, which assigned new users to the "Longer conversations" default with a random draw. This replaces the draw with a deterministic assignment: a new user gets "Longer conversations" when their `person.id` is even, and "Match percentage" when it is odd. Since `person.id` comes from a sequence, that is a 50-50 split.

The point of doing it this way is that the arm a user is in stays recoverable after the fact. `search_preference.sort_by_id` changes as soon as the user picks a different sort, so with a random draw there was no way to tell later which arm someone started in. With parity, the assignment can be recomputed from the person ID at analysis time, no matter what the user has changed since.

Details:

- `Q_FINISH_ONBOARDING`'s `default_sort_by` CTE now reads `MOD(new_person.id, 2) = 0` instead of `random() < share`. The `MATERIALIZED` hint is gone: it was only there to stop `random()` being evaluated separately for each of the `sort_by_id`, `min_age`, `max_age` and `distance` columns, and a parity test on a single ID is already consistent across all four.
- `LONGER_CONVERSATIONS_DEFAULT_SHARE` (a float share) becomes `LONGER_CONVERSATIONS_DEFAULT_TRIAL` (a boolean, defaulting to on), since a share no longer has any meaning when the split is fixed at 50-50. It stays as an env-backed switch so the trial can be turned off in a deployment without a code change, and so `docker-compose.test.yml` can keep the functional suite on the current defaults, which it still depends on.
- As in #1552, users in the "Longer conversations" arm also get their age and furthest-distance filters left unset, and existing users are untouched.

Verified by rendering `Q_FINISH_ONBOARDING` with literal parameters and running `EXPLAIN` on it inside a rolled-back transaction against a copy of the production database: the query plans, and the `sort_by` lookup shows the expected `CASE WHEN mod(new_person.id, 2) = 0 THEN 'Longer conversations' ELSE 'Match percentage' END` filter. `mypy` passes on `service/api/person/`. The functional suite was not run here; as before, it exercises only the control arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
