### PR TITLE
Stop the colour picker's sliders resetting on black and white

### DIFF
--- a/frontend/components/modal/color-picker-modal/color-picker-modal.tsx
+++ b/frontend/components/modal/color-picker-modal/color-picker-modal.tsx
@@ -22,6 +22,11 @@ import {
   HsvColorPickerRef,
 } from './hsv-color-picker';
 import {
+  Hsv,
+  hexToHsv,
+  hsvToHex,
+} from './util';
+import {
   DefaultText,
 } from '../../default-text';
 import {
@@ -119,16 +124,17 @@ const ColorPickerModal: React.FC = () => {
   }, [setIsShowing, shouldShow, opacity]);
 
   const hsvColorPickerRef = useRef<HsvColorPickerRef>(null);
+  const hsv = useRef<Hsv>([0, 0, 1]);
   const [backgroundColor, setBackgroundColor] = useState(initialBackgroundColor);
 
   const onDragMove = useCallback(() => {
-    setBackgroundColor(hsvColorPickerRef.current?.getColor() ?? '#ffffff');
+    hsv.current = hsvColorPickerRef.current?.getHsv() ?? hsv.current;
+
+    setBackgroundColor(hsvToHex(...hsv.current));
   }, []);
 
   const pick = useCallback(() => {
-    const color = hsvColorPickerRef.current?.getColor() ?? '#ffffff';
-
-    notify<ColorPickedEvent>('color-picked', color);
+    notify<ColorPickedEvent>('color-picked', hsvToHex(...hsv.current));
 
     setShouldShow(false);
   }, []);
@@ -150,9 +156,13 @@ const ColorPickerModal: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (shouldShow) {
-      hsvColorPickerRef.current?.setColor(initialBackgroundColor);
+    if (!shouldShow) {
+      return;
     }
+
+    hsv.current = hexToHsv(initialBackgroundColor, hsv.current);
+
+    hsvColorPickerRef.current?.setHsv(hsv.current);
   }, [hsvColorPickerRef.current, initialBackgroundColor, shouldShow]);
 
   const Button = ({onPress, title, color}: {

--- a/frontend/components/modal/color-picker-modal/hsv-color-picker.tsx
+++ b/frontend/components/modal/color-picker-modal/hsv-color-picker.tsx
@@ -18,8 +18,7 @@ import {
   SaturationValuePickerRef,
 } from './saturation-value-picker';
 import {
-  hexToHsv,
-  hsvToHex,
+  Hsv,
 } from './util';
 
 type HsvColorPickerProps = {
@@ -33,15 +32,12 @@ type HsvColorPickerProps = {
   satValPickerBorderRadius?: number;
   satValPickerSize?: number;
   satValPickerSliderSize?: number;
-  hue?: number,
-  saturation?: number,
-  value?: number,
   onDragMove?: () => void;
 }
 
 type HsvColorPickerRef = {
-  getColor: () => string;
-  setColor: (c: string) => void;
+  getHsv: () => Hsv;
+  setHsv: (hsv: Hsv) => void;
 };
 
 const HsvColorPicker = forwardRef<
@@ -51,43 +47,27 @@ const HsvColorPicker = forwardRef<
   const saturationValuePickerRef = useRef<SaturationValuePickerRef>(null);
   const huePickerRef = useRef<HuePickerRef>(null);
 
-  const transportHue = useCallback(() => {
+  const onHuePickerDragMove = useCallback(() => {
     const hue = huePickerRef.current?.getHue() ?? 0;
     saturationValuePickerRef.current?.setHue(hue);
-  }, []);
-
-  const onSatValPickerDragMove = useCallback(() => {
-    props.onDragMove && props.onDragMove();
-  }, []);
-
-  const onHuePickerDragMove = useCallback(() => {
-    transportHue();
 
     props.onDragMove && props.onDragMove();
   }, [props.onDragMove]);
 
-  const getColor = useCallback(() => {
-    return hsvToHex(
-      huePickerRef.current?.getHue() ?? 0,
-      saturationValuePickerRef.current?.getSaturation() ?? 0,
-      saturationValuePickerRef.current?.getValue() ?? 0,
-    );
-  }, [huePickerRef.current, saturationValuePickerRef.current]);
+  const getHsv = useCallback((): Hsv => [
+    huePickerRef.current?.getHue() ?? 0,
+    saturationValuePickerRef.current?.getSaturation() ?? 0,
+    saturationValuePickerRef.current?.getValue() ?? 0,
+  ], []);
 
-  const setColor = useCallback((c: string) => {
-    const [h, s, v] = hexToHsv(c);
-
+  const setHsv = useCallback(([h, s, v]: Hsv) => {
     huePickerRef.current?.setHue(h);
     saturationValuePickerRef.current?.setHue(h);
     saturationValuePickerRef.current?.setSaturation(s);
     saturationValuePickerRef.current?.setValue(v);
-  }, [huePickerRef.current, saturationValuePickerRef.current]);
+  }, []);
 
-  useImperativeHandle(
-    ref,
-    () => ({ getColor, setColor }),
-    [getColor, setColor],
-  );
+  useImperativeHandle(ref, () => ({ getHsv, setHsv }), [getHsv, setHsv]);
 
   return (
     <View style={[styles.container, props.containerStyle]}>
@@ -96,16 +76,12 @@ const HsvColorPicker = forwardRef<
         borderRadius={props.satValPickerBorderRadius ?? 0}
         size={props.satValPickerSize ?? 200}
         sliderSize={props.satValPickerSliderSize ?? 24}
-        hue={props.hue ?? 0}
-        saturation={props.saturation ?? 0}
-        value={props.value ?? 0}
-        onDragMove={onSatValPickerDragMove}
+        onDragMove={props.onDragMove}
         ref={saturationValuePickerRef}
       />
       <HuePicker
         containerStyle={props.huePickerContainerStyle}
         borderRadius={props.huePickerBorderRadius ?? 0}
-        hue={props.hue ?? 0}
         barWidth={props.huePickerBarWidth ?? 12}
         barHeight={props.huePickerBarHeight ?? 200}
         sliderSize={props.huePickerSliderSize ?? 24}

--- a/frontend/components/modal/color-picker-modal/hue-picker.tsx
+++ b/frontend/components/modal/color-picker-modal/hue-picker.tsx
@@ -21,7 +21,6 @@ import {
 
 type HuePickerProps = {
   borderRadius: number;
-  hue: number;
   barWidth: number;
   barHeight: number;
   sliderSize: number;
@@ -40,7 +39,6 @@ const HuePicker = forwardRef<
 >((props, ref) => {
   const {
     borderRadius,
-    hue,
     barWidth,
     barHeight,
     sliderSize,
@@ -58,11 +56,9 @@ const HuePicker = forwardRef<
     '#ff0000',
   ];
 
-  const initialY = clamp(hue, 0, 360);
-
-  const baseSliderY = useRef(initialY);
-  const sliderY = useRef(initialY);
-  const animatedSliderY = useRef(new Animated.Value(initialY));
+  const baseSliderY = useRef(0);
+  const sliderY = useRef(0);
+  const animatedSliderY = useRef(new Animated.Value(0));
 
   const backgroundColor = animatedSliderY.current.interpolate({
     inputRange: hueColors.map((_, i) => i * barHeight / (hueColors.length - 1)),

--- a/frontend/components/modal/color-picker-modal/saturation-value-picker.tsx
+++ b/frontend/components/modal/color-picker-modal/saturation-value-picker.tsx
@@ -32,9 +32,6 @@ type SaturationValuePickerProps = {
   borderRadius: number;
   size: number;
   sliderSize: number;
-  hue: number;
-  saturation: number;
-  value: number;
   containerStyle?: ViewStyle;
   onDragMove?: () => void;
 }
@@ -47,9 +44,6 @@ const SaturationValuePicker = forwardRef<
     borderRadius,
     size,
     sliderSize,
-    hue: initialHue,
-    saturation,
-    value,
     containerStyle = {},
     onDragMove,
   } = props;
@@ -64,13 +58,10 @@ const SaturationValuePicker = forwardRef<
     '#ff0000',
   ];
 
-  const initialXY = {
-    x: clamp(size * saturation),
-    y: clamp(size * value),
-  };
+  const initialXY = { x: 0, y: 0 };
 
-  const hue = useRef(initialHue);
-  const animatedHue = useRef(new Animated.Value(initialHue));
+  const hue = useRef(0);
+  const animatedHue = useRef(new Animated.Value(0));
 
   const baseSliderXY = useRef(initialXY);
   const sliderXY = useRef(initialXY);

--- a/frontend/components/modal/color-picker-modal/util.tsx
+++ b/frontend/components/modal/color-picker-modal/util.tsx
@@ -1,3 +1,5 @@
+type Hsv = [number, number, number];
+
 const clamp = (value: number, min: number = 0, max: number = 1) =>
   Math.min(Math.max(value, min), max);
 
@@ -98,9 +100,9 @@ const hexToRgb = (hex: string): [number, number, number] => {
  * @param {number} r - The red component.
  * @param {number} g - The green component.
  * @param {number} b - The blue component.
- * @return {[number, number, number]} The HSV representation (hue, saturation, value).
+ * @return {Hsv} The HSV representation (hue, saturation, value).
  */
-const rgbToHsv = (r: number, g: number, b: number): [number, number, number] => {
+const rgbToHsv = (r: number, g: number, b: number): Hsv => {
   r /= 255;
   g /= 255;
   b /= 255;
@@ -126,15 +128,27 @@ const rgbToHsv = (r: number, g: number, b: number): [number, number, number] => 
 /**
  * Converts a HEX color value directly to HSV.
  *
+ * Grey hexes leave the hue undetermined and black leaves the saturation
+ * undetermined too, so those components are taken from `fallback` instead of
+ * being flattened to zero.
+ *
  * @param {string} hex - The HEX color string.
- * @return {[number, number, number]} The HSV representation (hue, saturation, value).
+ * @param {Hsv} fallback - The HSV to take under-determined components from.
+ * @return {Hsv} The HSV representation (hue, saturation, value).
  */
-const hexToHsv = (hex: string): [number, number, number] => {
+const hexToHsv = (hex: string, fallback: Hsv): Hsv => {
   const [r, g, b] = hexToRgb(hex);
-  return rgbToHsv(r, g, b);
+  const [h, s, v] = rgbToHsv(r, g, b);
+
+  return [
+    s === 0 ? fallback[0] : h,
+    v === 0 ? fallback[1] : s,
+    v,
+  ];
 };
 
 export {
+  Hsv,
   clamp,
   hsvToHex,
   hexToHsv,


### PR DESCRIPTION
Fixes #1532.

## The bug

The colour picker's only persistent representation of the chosen colour was its hex code, and the modal re-derived both sliders' positions from that hex every time it opened.

Hex under-determines HSV: a grey pins nothing about the hue, and black pins nothing about the hue *or* the saturation. So the reconstruction guessed zero for whatever the hex didn't constrain. Pick black with the hue slider on green, reopen the picker, and the hue slider had snapped back to red with the saturation/value knob back at the left edge.

Measured before the fix (knob screen coordinates, driven through the real modal in Chrome):

```
open #00ff00      -> satval(694,290)  hue(712,356)
drag satval down  -> new swatch = black,  hue knob unmoved
reopen #000000    -> satval(494,490)  hue(712,290)   <- hue and saturation lost
```

Dragging within a single session was always fine, which is why the symptom reads as one slider snapping back after you drive the other to an extreme.

## The fix

- The picker's imperative interface is now HSV (`getHsv`/`setHsv`) rather than hex, so slider positions are never round-tripped through a representation that can't hold them.
- The modal is the single place hex meets HSV. It remembers the HSV it last displayed and passes it to `hexToHsv` as the source of any component the incoming hex leaves undetermined.
- Dropped the `hue`, `saturation` and `value` props from both sliders. Nothing passed them, and their initial-position arithmetic was wrong regardless: `clamp(size * saturation)` clamped a pixel offset to `[0, 1]`, and the hue was used as a Y coordinate without being scaled by the bar's height.

## Verification

Driven through the real picker in Chrome via Playwright:

```
drag satval to black -> picked #000000
reopen black         -> satval(694,490)  hue(712,356)   <- both preserved
drag back up         -> green, not red
reopen white         -> hue still on blue, sat knob where it was left
open #3366cc         -> picked back unchanged as #3366cc
```

`tsc --noEmit` and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
