### PR TITLE
Keep the old default search filters in the "Longer conversations" arm

### DIFF
--- a/backend/service/api/person/sql/__init__.py
+++ b/backend/service/api/person/sql/__init__.py
@@ -516,24 +516,19 @@ WITH onboardee_location AS (
         1
 ), default_sort_by AS (
     SELECT
-        longer_conversations,
         (
             SELECT id
             FROM sort_by
             WHERE name = CASE
-                WHEN longer_conversations
+                WHEN
+                    %(longer_conversations_default_trial)s::BOOLEAN
+                    AND MOD(new_person.id, 2) = 0
                 THEN '{SORT_KV}'
                 ELSE '{SORT_MATCH_PERCENTAGE}'
             END
         ) AS id
-    FROM (
-        SELECT
-            %(longer_conversations_default_trial)s::BOOLEAN
-                AND MOD(new_person.id, 2) = 0
-                AS longer_conversations
-        FROM
-            new_person
-    ) AS assignment
+    FROM
+        new_person
 ), updated_session AS (
     UPDATE duo_session
     SET person_id = new_person.id
@@ -587,22 +582,9 @@ WITH onboardee_location AS (
         ARRAY(SELECT id FROM frequency ORDER BY id),
         ARRAY(SELECT id FROM religion ORDER BY id),
         ARRAY(SELECT id FROM star_sign ORDER BY id),
+        best_age.min_age,
+        best_age.max_age,
         CASE
-            WHEN default_sort_by.longer_conversations
-            THEN NULL
-
-            ELSE best_age.min_age
-        END,
-        CASE
-            WHEN default_sort_by.longer_conversations
-            THEN NULL
-
-            ELSE best_age.max_age
-        END,
-        CASE
-            WHEN default_sort_by.longer_conversations
-            THEN NULL
-
             WHEN best_distance.cnt < 500
             THEN NULL
 


### PR DESCRIPTION
Follows #1552 and #1555.

The trial as it stands gives users assigned the "Longer conversations" default two changes at once: the sort itself, and their age and furthest-distance filters left unset instead of the computed best-age / best-distance defaults. The measured result was worse retention in that arm — or users switching away from the sort — but the two changes are confounded, so it isn't clear which one caused it.

This variant keeps the parity-based sort assignment and drops the filter half. Every new user now gets the same `min_age`, `max_age` and `distance` defaults as before the trial, whichever arm they are in, so the only difference between arms is the sort.

Details:

- The three `CASE WHEN default_sort_by.longer_conversations THEN NULL` branches on `min_age`, `max_age` and `distance` in `Q_FINISH_ONBOARDING` are gone. `min_age` and `max_age` are back to plain `best_age.min_age` / `best_age.max_age`, and `distance` is back to the `best_distance` `CASE` with only its original rules: null when fewer than 500 people are nearby, capped at 8000 km, null when the user is joining a club.
- With that, the `default_sort_by` CTE no longer needs to expose the `longer_conversations` boolean to the rest of the query, so its wrapper subquery collapses into the `sort_by` lookup itself. The parity test `MOD(new_person.id, 2) = 0`, gated by `DUO_LONGER_CONVERSATIONS_DEFAULT_TRIAL`, is unchanged in behaviour, and the env variable keeps its name so deployment config doesn't have to change.
- Existing users are untouched, including those who signed up during the current trial and already have null age and distance filters written to `search_preference`. The retention comparison will therefore need to separate sign-up cohorts by date, not only by person ID parity across the whole table.

Verified by rendering `Q_FINISH_ONBOARDING` and running `EXPLAIN` on it against a copy of the production database inside a rolled-back transaction. It plans, and with the trial flag on the plan shows the expected `name = CASE WHEN (mod(new_person.id, 2) = 0) THEN 'Longer conversations' ELSE 'Match percentage' END` filter on the `sort_by` lookup; with the flag off Postgres folds it to the constant `'Match percentage'`. `mypy` was not run — it needs `pydantic`, which isn't installed outside the container — but the change touches only the SQL string and no Python types. The functional suite was not run either; `docker-compose.test.yml` still pins the trial off, so the suite exercises the control arm exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)