### PR TITLE
End the age-bounds A/B test in favour of the original defaults

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -43,8 +43,6 @@ services:
     environment:
       DUO_ENV: dev
 
-      DUO_AGE_BOUNDS_TRIAL: 'false'
-
       # Unit-test discovery runs in this container and imports
       # service.cron, which fails fast without this or an OpenAI key.
       DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION: 'A friendly description for this club.'

--- a/backend/service/api/person/__init__.py
+++ b/backend/service/api/person/__init__.py
@@ -5,7 +5,6 @@ from serviceshared.database import (
     row_bool,
     row_int,
     row_int_list_or_none,
-    row_str,
 )
 from serviceshared.database._row import row_int_or_none
 from collections.abc import Mapping, Sequence
@@ -63,10 +62,7 @@ from serviceshared.verification.messages import (
 )
 
 
-from serviceshared.duoenv.api import (
-    AGE_BOUNDS_TRIAL,
-    ENV as DUO_ENV,
-)
+from serviceshared.duoenv.api import ENV as DUO_ENV
 from serviceshared.duoenv.shared import R2_ACCT_ID
 
 logger = logging.getLogger(__name__)
@@ -140,48 +136,19 @@ def _otp_from_rows(rows: Sequence[Mapping[str, object]]) -> str | None:
     except:
         return None
 
-async def _person_age_and_gender(tx: Tx, person_id: int) -> tuple[int, str]:
-    row = await tx.require_one(
-        Q_PERSON_AGE_AND_GENDER,
-        params=dict(person_id=person_id),
+async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
+    age = row_int(
+        await tx.require_one(Q_PERSON_AGE, params=dict(person_id=person_id)),
+        'age',
     )
-    return row_int(row, 'age'), row_str(row, 'gender')
-
-
-async def _update_best_age_filters(tx: Tx, person_id: int) -> None:
-    age, gender = await _person_age_and_gender(tx, person_id)
-
-    # The 50-50 split keys on `person.id` parity, drawn from `person_id_seq`
-    # at insert time, so the arm stays recoverable from the id alone even
-    # after the user changes their filters.
-    trial = AGE_BOUNDS_TRIAL and person_id % 2 == 0
-    bounds = best_age(age=age, gender=gender, trial=trial)
-
-    await tx.execute(Q_UPDATE_SEARCH_PREFERENCE_AGE, params=dict(
-        person_id=person_id,
-        min_age=bounds.min_age,
-        max_age=bounds.max_age,
-    ))
-
-
-async def _update_best_distance(tx: Tx, person_id: int) -> None:
-    age, gender = await _person_age_and_gender(tx, person_id)
-
-    # Counts candidates through the control arm's age window regardless of
-    # which arm this person is in, so the trial's wider window can't also
-    # shrink the distance default and confound the age-bounds comparison.
-    control_bounds = best_age(age=age, gender=gender, trial=False)
+    bounds = best_age(age)
 
     async def count_within(distance_km: float) -> int:
         counted = await tx.require_one(Q_COUNT_NEARBY_CANDIDATES, params=dict(
             person_id=person_id,
             distance_metres=distance_km * 1000,
-            min_age=(
-                0 if control_bounds.min_age is None else control_bounds.min_age
-            ),
-            max_age=(
-                999 if control_bounds.max_age is None else control_bounds.max_age
-            ),
+            min_age=0 if bounds.min_age is None else bounds.min_age,
+            max_age=999 if bounds.max_age is None else bounds.max_age,
             candidate_limit=CANDIDATE_LIMIT,
         ))
         return row_int(counted, 'candidates')
@@ -193,8 +160,10 @@ async def _update_best_distance(tx: Tx, person_id: int) -> None:
         'is_joining_club',
     )
 
-    await tx.execute(Q_UPDATE_SEARCH_PREFERENCE_DISTANCE, params=dict(
+    await tx.execute(Q_UPDATE_BEST_SEARCH_PREFERENCES, params=dict(
         person_id=person_id,
+        min_age=bounds.min_age,
+        max_age=bounds.max_age,
         distance=distance_preference(candidates, is_joining_club=is_joining_club),
     ))
 
@@ -675,11 +644,10 @@ async def post_finish_onboarding(s: t.SessionInfo) -> object:
         # `person_id` comes from the INSERT's own sequence rather than one of
         # its params, so this write's subject has to be named here, in the
         # one-statement window right after it runs and before anything else
-        # touches the transaction -- including the two calls below.
+        # touches the transaction -- including the call below.
         tx.attribute([person_id])
 
-        await _update_best_distance(tx, person_id)
-        await _update_best_age_filters(tx, person_id)
+        await _update_best_search_preferences(tx, person_id)
 
         # If this user signed up via Google/Apple, drain the pending
         # provider identity from `duo_session` into `social_identity` now

--- a/backend/service/api/person/bestage/__init__.py
+++ b/backend/service/api/person/bestage/__init__.py
@@ -10,59 +10,10 @@ class AgeBounds:
     max_age: int | None
 
 
-def _line(slope: float, intercept: float, age: int) -> int:
-    return round(slope * age + intercept)
-
-
-def _control_min_age(age: int) -> int:
-    return _line(0.8, 1.6, age)
-
-
-def _control_max_age(age: int) -> int:
-    return _line(1.2, -1.6, age)
-
-
-def _trial_man_min_age(age: int) -> int:
-    return _line(0.75, 1.25, age)
-
-
-def _trial_man_max_age(age: int) -> int:
-    return _line(1.25, -1.25, age)
-
-
-def _trial_woman_max_age(age: int) -> int:
-    return _line(2.2, -19.0, age)
-
-
-def _clamp_min_age(min_age: int) -> int | None:
-    return None if min_age <= _AGE_FLOOR else min_age
-
-
-def _clamp_max_age(max_age: int) -> int | None:
-    return None if max_age >= _AGE_CEILING else max_age
-
-
-def best_age(age: int, gender: str, trial: bool) -> AgeBounds:
-    if not trial:
-        return AgeBounds(
-            min_age=_clamp_min_age(_control_min_age(age)),
-            max_age=_clamp_max_age(_control_max_age(age)),
-        )
-
-    if gender == 'Man':
-        min_age = _trial_man_min_age(age)
-        max_age = _trial_man_max_age(age)
-    elif gender == 'Woman':
-        # Unchanged by the trial: women get the same lower bound as everyone
-        # not in the "Man" or "Woman" branches below.
-        min_age = _control_min_age(age)
-        max_age = _trial_woman_max_age(age)
-    else:
-        # Every gender besides "Man" and "Woman" is unaffected by the trial.
-        min_age = _control_min_age(age)
-        max_age = _control_max_age(age)
-
+def best_age(age: int) -> AgeBounds:
+    min_age = round(0.8 * age + 1.6)
+    max_age = round(1.2 * age - 1.6)
     return AgeBounds(
-        min_age=_clamp_min_age(min_age),
-        max_age=_clamp_max_age(max_age),
+        min_age=None if min_age <= _AGE_FLOOR else min_age,
+        max_age=None if max_age >= _AGE_CEILING else max_age,
     )

--- a/backend/service/api/person/sql/__init__.py
+++ b/backend/service/api/person/sql/__init__.py
@@ -317,18 +317,13 @@ ON
     valid_session.person_id = existing_person.id
 """
 
-Q_PERSON_AGE_AND_GENDER = """
+Q_PERSON_AGE = """
 SELECT
-    EXTRACT(YEAR FROM AGE(person.date_of_birth))::INT AS age,
-    gender.name AS gender
+    EXTRACT(YEAR FROM AGE(date_of_birth))::INT AS age
 FROM
     person
-JOIN
-    gender
-ON
-    gender.id = person.gender_id
 WHERE
-    person.id = %(person_id)s
+    id = %(person_id)s
 """
 
 Q_COUNT_NEARBY_CANDIDATES = """
@@ -379,16 +374,6 @@ FROM (
 ) AS candidate
 """
 
-Q_UPDATE_SEARCH_PREFERENCE_AGE = """
-UPDATE
-    search_preference
-SET
-    min_age = %(min_age)s,
-    max_age = %(max_age)s
-WHERE
-    person_id = %(person_id)s
-"""
-
 Q_IS_JOINING_CLUB = """
 SELECT
     EXISTS (
@@ -399,10 +384,12 @@ SELECT
     ) AS is_joining_club
 """
 
-Q_UPDATE_SEARCH_PREFERENCE_DISTANCE = """
+Q_UPDATE_BEST_SEARCH_PREFERENCES = """
 UPDATE
     search_preference
 SET
+    min_age = %(min_age)s,
+    max_age = %(max_age)s,
     distance = %(distance)s::NUMERIC::SMALLINT
 WHERE
     person_id = %(person_id)s

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -1,6 +1,5 @@
 from serviceshared.duoenv.read import (
     csv,
-    flag_with,
     float_with,
     int_with,
     required_str,
@@ -34,5 +33,3 @@ APPLE_ANDROID_REDIRECT_URL = stripped_str('DUO_APPLE_ANDROID_REDIRECT_URL')
 
 VAPID_SUBJECT = str_with('DUO_VAPID_SUBJECT', 'mailto:support@duolicious.app')
 VAPID_PRIVATE_KEY = str_with('DUO_VAPID_PRIVATE_KEY', '')
-
-AGE_BOUNDS_TRIAL = flag_with('DUO_AGE_BOUNDS_TRIAL', 'true')


### PR DESCRIPTION
Ends the trial from #1565. The original coefficients won, so every new user now gets the pre-trial age bounds and the per-gender rules are removed along with `DUO_AGE_BOUNDS_TRIAL`.

The age and distance searches stay in Python. With the trial gone the distance search no longer needs a separate "control window": it counts candidates through the same window the user is given, which is what the recursive CTE did before #1565. The age and distance writes now go out as a single `UPDATE`.

## What changes for a new user

Nothing, compared with the control arm. `best_age` reproduces `round(age - 2 - (age - 18) / 5.0)` and `round(age + 2 + (age - 18) / 5.0)` with the same 18 and 99 clamps. Checked at every age from 18 to 129 against a half-up decimal evaluation of the original SQL, no mismatches. The distance search is untouched.

## Verification

- `mypy.sh` passes over all 229 source files.
- No local DB run; relying on CI for the functional suite. The test compose file no longer needs to pin the trial off since the flag is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
