### PR TITLE
Default half of new users to the "Distance" sort as an A/B arm

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -43,6 +43,8 @@ services:
     environment:
       DUO_ENV: dev
 
+      DUO_DISTANCE_SORT_TRIAL: 'false'
+
       # Unit-test discovery runs in this container and imports
       # service.cron, which fails fast without this or an OpenAI key.
       DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION: 'A friendly description for this club.'

--- a/backend/service/api/person/__init__.py
+++ b/backend/service/api/person/__init__.py
@@ -10,13 +10,14 @@ from serviceshared.database._row import row_int_or_none
 from collections.abc import Mapping, Sequence
 from typing import Tuple
 from serviceshared.util.coerce import string
-from service.api.person.bestage import best_age
+from service.api.person.bestage import AgeBounds, best_age
 from service.api.person.bestdistance import (
     CANDIDATE_LIMIT,
     best_distance,
     distance_preference,
 )
 from service.api.person.urlslug import reserve_onboardee_url_slug
+from service.api.search.sql.search import SORT_DISTANCE, SORT_MATCH_PERCENTAGE
 import service.api.duotypes as t
 import json
 import secrets
@@ -62,7 +63,10 @@ from serviceshared.verification.messages import (
 )
 
 
-from serviceshared.duoenv.api import ENV as DUO_ENV
+from serviceshared.duoenv.api import (
+    DISTANCE_SORT_TRIAL,
+    ENV as DUO_ENV,
+)
 from serviceshared.duoenv.shared import R2_ACCT_ID
 
 logger = logging.getLogger(__name__)
@@ -136,13 +140,11 @@ def _otp_from_rows(rows: Sequence[Mapping[str, object]]) -> str | None:
     except:
         return None
 
-async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
-    age = row_int(
-        await tx.require_one(Q_PERSON_AGE, params=dict(person_id=person_id)),
-        'age',
-    )
-    bounds = best_age(age)
-
+async def _best_distance(
+    tx: Tx,
+    person_id: int,
+    bounds: AgeBounds,
+) -> float | None:
     async def count_within(distance_km: float) -> int:
         counted = await tx.require_one(Q_COUNT_NEARBY_CANDIDATES, params=dict(
             person_id=person_id,
@@ -160,11 +162,26 @@ async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
         'is_joining_club',
     )
 
+    return distance_preference(candidates, is_joining_club=is_joining_club)
+
+
+async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
+    age = row_int(
+        await tx.require_one(Q_PERSON_AGE, params=dict(person_id=person_id)),
+        'age',
+    )
+    bounds = best_age(age)
+
+    # The 50-50 split keys on `person.id` parity so the arm stays
+    # recoverable from the id alone after the user changes their filters.
+    trial = DISTANCE_SORT_TRIAL and person_id % 2 == 0
+
     await tx.execute(Q_UPDATE_BEST_SEARCH_PREFERENCES, params=dict(
         person_id=person_id,
         min_age=bounds.min_age,
         max_age=bounds.max_age,
-        distance=distance_preference(candidates, is_joining_club=is_joining_club),
+        distance=None if trial else await _best_distance(tx, person_id, bounds),
+        sort_by=SORT_DISTANCE if trial else SORT_MATCH_PERCENTAGE,
     ))
 
 

--- a/backend/service/api/person/sql/__init__.py
+++ b/backend/service/api/person/sql/__init__.py
@@ -5,7 +5,6 @@ from serviceshared.constants import (
     MAX_RELATED_CLUBS,
     MIN_CLUB_PAGE_MEMBERS,
 )
-from service.api.search.sql.search import SORT_MATCH_PERCENTAGE
 from serviceshared.commonsql import (
     PHOTO_GEOMETRY,
     Q_COMPUTED_FLAIR,
@@ -390,7 +389,8 @@ UPDATE
 SET
     min_age = %(min_age)s,
     max_age = %(max_age)s,
-    distance = %(distance)s::NUMERIC::SMALLINT
+    distance = %(distance)s::NUMERIC::SMALLINT,
+    sort_by_id = (SELECT id FROM sort_by WHERE name = %(sort_by)s)
 WHERE
     person_id = %(person_id)s
 """
@@ -491,7 +491,6 @@ WITH onboardee_location AS (
         religion_ids,
         star_sign_ids,
         last_online_id,
-        sort_by_id,
         show_messaged,
         show_skipped
     )
@@ -519,7 +518,6 @@ WITH onboardee_location AS (
         ARRAY(SELECT id FROM religion ORDER BY id),
         ARRAY(SELECT id FROM star_sign ORDER BY id),
         (SELECT id FROM last_online WHERE name = '{LAST_ONLINE_DEFAULT_NAME}'),
-        (SELECT id from sort_by where name = '{SORT_MATCH_PERCENTAGE}'),
         TRUE,
         FALSE
     FROM new_person

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -1,5 +1,6 @@
 from serviceshared.duoenv.read import (
     csv,
+    flag_with,
     float_with,
     int_with,
     required_str,
@@ -33,3 +34,5 @@ APPLE_ANDROID_REDIRECT_URL = stripped_str('DUO_APPLE_ANDROID_REDIRECT_URL')
 
 VAPID_SUBJECT = str_with('DUO_VAPID_SUBJECT', 'mailto:support@duolicious.app')
 VAPID_PRIVATE_KEY = str_with('DUO_VAPID_PRIVATE_KEY', '')
+
+DISTANCE_SORT_TRIAL = flag_with('DUO_DISTANCE_SORT_TRIAL', 'true')


### PR DESCRIPTION
New users with an even `person.id` get "Distance" as their default "Sort By" and no "Furthest distance" limit. Odd ids keep "Match percentage" and the solved distance, exactly as today. `DUO_DISTANCE_SORT_TRIAL` turns the arm on and defaults to on; the test compose file pins it off so the functional suite sees the control arm.

## How it is wired

The sort default moves out of the onboarding `INSERT` into the `UPDATE` that already writes the solved age bounds and distance, so the arm is decided once in Python and all four columns land in one statement. Trial users skip the distance search entirely, which also saves its five count queries. The age bounds are the same in both arms.

The split keys on `person.id` parity so the arm stays recoverable at analysis time. Previous trials keyed on the same parity, so cohorts have to be separated by sign-up date as well, the same caveat as #1561 and #1565.

## Worth knowing

- The frontend's "reset filters" builder hard-codes "Match percentage" as the sort default, so a trial user who resets their filters lands in the control configuration. That was also true of the "Longer conversations" trial and is left as is.
- A trial user's search is unbounded by distance from the start, ordered nearest first. The "Distance" sort orders by great-circle distance to the searcher, so a searcher without coordinates is the same edge case as before this change.

## Verification

- `mypy.sh` passes over all 229 source files.
- Relying on CI for the functional suite; it runs the control arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)