### PR TITLE
Spotify: return to the apex host, and fail the connect when the artist fetch fails

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -100,6 +100,7 @@ services:
       DUO_SPOTIFY_TOKEN_URL: http://spotifymock:3003/api/token
       DUO_SPOTIFY_API_URL: http://spotifymock:3003
       DUO_SPOTIFY_WEB_REDIRECT_URL: http://test-web.example/
+      DUO_SPOTIFY_APEX_REDIRECT_URL: http://test-apex.example/
       DUO_SPOTIFY_APP_REDIRECT_URL: http://test-app.example/
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       DUO_SPOTIFY_TOKEN_URL: http://spotifymock:3003/api/token
       DUO_SPOTIFY_API_URL: http://spotifymock:3003
       DUO_SPOTIFY_WEB_REDIRECT_URL: http://localhost:8081/profile
+      DUO_SPOTIFY_APEX_REDIRECT_URL: http://localhost:8081/profile
       DUO_SPOTIFY_APP_REDIRECT_URL: app.duolicious://spotify
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -652,7 +652,7 @@ CREATE TABLE IF NOT EXISTS person_spotify (
     person_id INT PRIMARY KEY REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,
     refresh_token TEXT NOT NULL,
     attempted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    artists_synced_at TIMESTAMP,
+    artists_synced_at TIMESTAMP NOT NULL DEFAULT NOW(),
     top_artists JSONB NOT NULL DEFAULT '[]'
 );
 

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS person_spotify (
     person_id INT PRIMARY KEY REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,
     refresh_token TEXT NOT NULL,
     attempted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    artists_synced_at TIMESTAMP,
+    artists_synced_at TIMESTAMP NOT NULL DEFAULT NOW(),
     top_artists JSONB NOT NULL DEFAULT '[]'
 );
 

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -27,3 +27,7 @@ CREATE TABLE IF NOT EXISTS person_spotify (
 
 CREATE INDEX IF NOT EXISTS idx__person_spotify__attempted_at
     ON person_spotify(attempted_at);
+
+DELETE FROM person_spotify WHERE artists_synced_at IS NULL;
+ALTER TABLE person_spotify ALTER COLUMN artists_synced_at SET NOT NULL;
+ALTER TABLE person_spotify ALTER COLUMN artists_synced_at SET DEFAULT NOW();

--- a/backend/service/api/auth/spotify_oauth.py
+++ b/backend/service/api/auth/spotify_oauth.py
@@ -14,6 +14,7 @@ from serviceshared.spotify.sql import (
 )
 
 from serviceshared.duoenv.api import (
+    SPOTIFY_APEX_REDIRECT_URL,
     SPOTIFY_APP_REDIRECT_URL,
     SPOTIFY_AUTHORIZE_URL,
     SPOTIFY_REDIRECT_URI,
@@ -23,6 +24,7 @@ from serviceshared.duoenv.api import (
 
 _REDIRECT_TARGETS = {
     'web': SPOTIFY_WEB_REDIRECT_URL,
+    'apex': SPOTIFY_APEX_REDIRECT_URL,
     'app': SPOTIFY_APP_REDIRECT_URL,
 }
 
@@ -65,6 +67,8 @@ async def handle_callback(
         return redirect(target_url, spotify_error='exchange_failed')
 
     artists = await spotify.fetch_top_artists(tokens.access_token)
+    if artists is None:
+        return redirect(target_url, spotify_error='fetch_failed')
 
     async with api_tx() as tx:
         await tx.execute(Q_UPSERT_PERSON_SPOTIFY, dict(

--- a/backend/service/api/duotypes/__init__.py
+++ b/backend/service/api/duotypes/__init__.py
@@ -704,7 +704,7 @@ class PostSearchFilterAnswer(BaseModel):
 
 
 class PostSpotifyAuthorize(BaseModel):
-    redirect_target: Literal['web', 'app']
+    redirect_target: Literal['web', 'apex', 'app']
 
 
 class PostJoinClub(BaseModel):

--- a/backend/service/api/person/sql/__init__.py
+++ b/backend/service/api/person/sql/__init__.py
@@ -1374,9 +1374,7 @@ WITH photo_ AS (
     WHERE person_id = %(person_id)s
 
 ), spotify AS (
-    SELECT
-        top_artists,
-        artists_synced_at IS NOT NULL AS artists_synced
+    SELECT top_artists
     FROM person_spotify
     WHERE person_id = %(person_id)s
 
@@ -1496,7 +1494,6 @@ SELECT
 
         'spotify_artists',        COALESCE((SELECT top_artists FROM spotify), '[]'::jsonb),
         'spotify_connected',      EXISTS (SELECT 1 FROM spotify),
-        'spotify_artists_synced', COALESCE((SELECT artists_synced FROM spotify), FALSE),
         'spotify_tester',         (SELECT j FROM spotify_tester),
 
         'units',                  (SELECT j FROM unit),

--- a/backend/service/cron/spotifyrefresh/sql/__init__.py
+++ b/backend/service/cron/spotifyrefresh/sql/__init__.py
@@ -5,11 +5,7 @@ SELECT
 FROM
     person_spotify
 WHERE
-    (
-        artists_synced_at IS NULL
-    OR
-        artists_synced_at < NOW() - make_interval(days => %(max_age_days)s)
-    )
+    artists_synced_at < NOW() - make_interval(days => %(max_age_days)s)
 AND
     attempted_at < NOW() - make_interval(secs => %(retry_seconds)s)
 ORDER BY

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -44,6 +44,10 @@ SPOTIFY_WEB_REDIRECT_URL = str_with(
     'DUO_SPOTIFY_WEB_REDIRECT_URL',
     'https://web.duolicious.app/profile',
 )
+SPOTIFY_APEX_REDIRECT_URL = str_with(
+    'DUO_SPOTIFY_APEX_REDIRECT_URL',
+    'https://duolicious.app/profile',
+)
 SPOTIFY_APP_REDIRECT_URL = str_with(
     'DUO_SPOTIFY_APP_REDIRECT_URL',
     'app.duolicious://spotify',

--- a/backend/serviceshared/spotify/sql/__init__.py
+++ b/backend/serviceshared/spotify/sql/__init__.py
@@ -37,14 +37,12 @@ Q_UPSERT_PERSON_SPOTIFY = """
 INSERT INTO person_spotify (
     person_id,
     refresh_token,
-    top_artists,
-    artists_synced_at
+    top_artists
 )
 SELECT
     id,
     %(refresh_token)s,
-    COALESCE(%(top_artists)s::jsonb, '[]'::jsonb),
-    CASE WHEN %(top_artists)s::jsonb IS NULL THEN NULL ELSE NOW() END
+    %(top_artists)s::jsonb
 FROM
     person
 WHERE
@@ -53,7 +51,7 @@ ON CONFLICT (person_id) DO UPDATE SET
     refresh_token = EXCLUDED.refresh_token,
     attempted_at = NOW(),
     top_artists = EXCLUDED.top_artists,
-    artists_synced_at = EXCLUDED.artists_synced_at
+    artists_synced_at = NOW()
 """
 
 Q_UPDATE_PERSON_SPOTIFY = """

--- a/backend/test/functionality1/spotify.sh
+++ b/backend/test/functionality1/spotify.sh
@@ -89,7 +89,6 @@ connect_happy_path () {
   local profile=$(c GET /profile-info)
 
   [[ "$(jq -r '.spotify_connected' <<< "$profile")" == 'true' ]]
-  [[ "$(jq -r '.spotify_artists_synced' <<< "$profile")" == 'true' ]]
   [[ "$(jq -r '.spotify_tester' <<< "$profile")" == 'true' ]]
   j_assert_length "$(jq '.spotify_artists' <<< "$profile")" 10
   [[ "$(jq -r '.spotify_artists[0].name' <<< "$profile")" == 'Mock Artist One' ]]
@@ -249,35 +248,34 @@ cron_refreshes_artists () {
   j_assert_length "$(c GET /profile-info | jq '.spotify_artists')" 1
 }
 
-failed_initial_fetch_backfills () {
-  echo 'A failed artist fetch during connect is backfilled by the cron'
+failed_initial_fetch_fails_the_connect () {
+  echo 'A failed artist fetch during connect stores nothing and reports an error'
 
   setup
 
   set_spotify_mock_artists '[ {} ]'
 
-  connect_spotify
+  mint_state web
 
-  local profile=$(c GET /profile-info)
+  local location=$(callback_location "code=mock-code&state=$state")
 
-  [[ "$(jq -r '.spotify_connected' <<< "$profile")" == 'true' ]]
-  [[ "$(jq -r '.spotify_artists_synced' <<< "$profile")" == 'false' ]]
-  [[ "$(jq -c '.spotify_artists' <<< "$profile")" == '[]' ]]
+  [[ "$location" == 'http://test-web.example/?spotify_error=fetch_failed' ]]
 
-  reset_spotify_mock
+  [[ "$(c GET /profile-info | jq -r '.spotify_connected')" == 'false' ]]
 
-  sleep 2
+  [[ "$(q "select count(*) from person_spotify")" == "0" ]]
+}
 
-  [[ "$(q "select jsonb_array_length(top_artists) from person_spotify")" == "0" ]]
+apex_returns_to_the_apex_host () {
+  echo 'A flow started on the apex host returns to the apex host'
 
-  q "update person_spotify set attempted_at = now() - interval '2 minutes'"
+  setup
 
-  assert_eventually 10 q "select jsonb_array_length(top_artists) from person_spotify"
+  mint_state apex
 
-  profile=$(c GET /profile-info)
+  local location=$(callback_location "code=mock-code&state=$state")
 
-  [[ "$(jq -r '.spotify_artists_synced' <<< "$profile")" == 'true' ]]
-  j_assert_length "$(jq '.spotify_artists' <<< "$profile")" 10
+  [[ "$location" == 'http://test-apex.example/?spotify=connected' ]]
 }
 
 revocation_clears_tokens_and_artists () {
@@ -321,6 +319,7 @@ garbled_target_is_rejected
 user_denial_redirects_with_error
 disconnect_empties_everything
 cron_refreshes_artists
-failed_initial_fetch_backfills
+failed_initial_fetch_fails_the_connect
+apex_returns_to_the_apex_host
 revocation_clears_tokens_and_artists
 deleting_account_cascades

--- a/frontend/api/oauth-return.tsx
+++ b/frontend/api/oauth-return.tsx
@@ -46,6 +46,9 @@ const navigateAway = (url: string): Promise<void> =>
     window.location.assign(url);
   });
 
+const webReturnTarget = (): 'web' | 'apex' =>
+  window.location.hostname === 'duolicious.app' ? 'apex' : 'web';
+
 const parseQueryParams = (url: string): URLSearchParams => {
   // Some browsers/env may not populate URL.searchParams from a relative-ish
   // string; parse the query manually as a fallback.
@@ -62,4 +65,5 @@ export {
   navigateAway,
   parseQueryParams,
   takeWebReturnParams,
+  webReturnTarget,
 };

--- a/frontend/api/social-auth.tsx
+++ b/frontend/api/social-auth.tsx
@@ -10,6 +10,7 @@ import {
   navigateAway,
   parseQueryParams,
   takeWebReturnParams,
+  webReturnTarget,
 } from './oauth-return';
 import {
   APPLE_ANDROID_RETURN_URL,
@@ -375,9 +376,7 @@ const signInWithAppleWeb = async (
   // backend's callback must 302 back to the origin the flow started on —
   // the nonce lives in this origin's sessionStorage — so the state names
   // which entry of the backend's redirect allow-list to use.
-  const target =
-    window.location.hostname === 'duolicious.app' ? 'apex' : 'web';
-  const state = `${nonce}.${target}`;
+  const state = `${nonce}.${webReturnTarget()}`;
 
   const authUrl = _buildAppleAuthorizeUrl({
     clientId: APPLE_WEB_CLIENT_ID,

--- a/frontend/api/spotify.tsx
+++ b/frontend/api/spotify.tsx
@@ -5,6 +5,7 @@ import {
   navigateAway,
   parseQueryParams,
   takeWebReturnParams,
+  webReturnTarget,
 } from './oauth-return';
 import { notify } from '../events/events';
 import { DefaultText } from '../components/default-text';
@@ -56,7 +57,7 @@ const connectSpotify = async (): Promise<void> => {
   const response = await japi<PostSpotifyAuthorizeResponse>(
     'post',
     '/spotify/authorize',
-    { redirect_target: Platform.OS === 'web' ? 'web' : 'app' },
+    { redirect_target: Platform.OS === 'web' ? webReturnTarget() : 'app' },
   );
 
   if (!response.ok || !response.json) {

--- a/frontend/components/profile-tab.tsx
+++ b/frontend/components/profile-tab.tsx
@@ -503,9 +503,7 @@ const MusicSection = ({data}: {data: ProfileInfo}) => {
       }
       {isConnected && artists.length === 0 &&
         <MusicHint>
-          {data.spotify_artists_synced
-            ? 'Spotify hasn’t got enough listening history to pick your top artists yet'
-            : 'Your top Spotify artists will show up here once we’ve fetched them'}
+          Spotify hasn’t got enough listening history to pick your top artists yet
         </MusicHint>
       }
       <ButtonWithCenteredText

--- a/frontend/events/profile-info.tsx
+++ b/frontend/events/profile-info.tsx
@@ -53,7 +53,6 @@ type ProfileInfo = {
   clubs?: ClubItem[];
   spotify_artists?: SpotifyArtistItem[];
   spotify_connected?: boolean;
-  spotify_artists_synced?: boolean;
   spotify_tester?: boolean;
   public_profile?: string;
   photo?: { [position: string]: string | null };


### PR DESCRIPTION
Two fixes found while testing #1438 on prod after it merged.

## Return to the host the flow started on

The SPA is served on both `web.duolicious.app` and `duolicious.app`, but the Spotify callback only knew one web return target, so connecting from the apex host dropped the user on the web host. This adds a third target, `apex`, mirroring the Apple callback:

- `DUO_SPOTIFY_APEX_REDIRECT_URL`, defaulting to `https://duolicious.app/profile`, and `apex` in the callback's allow-list and in `PostSpotifyAuthorize.redirect_target`.
- The web client picks `web` or `apex` by hostname through a new `webReturnTarget()` in `api/oauth-return.tsx`, which the Apple web flow now uses too instead of its own inline check.
- Dev and test compose files set the new variable; a test covers the apex round trip.

## A failed artist fetch fails the connect

Previously the callback stored the refresh token even when the top-artists fetch failed, and the profile showed "your top artists will show up here once we've fetched them" while the cron retried in the background. That is a bad experience for a failure the user could simply retry. Now the callback stores nothing and redirects with `spotify_error=fetch_failed`, which the client shows as the usual "couldn't connect" toast.

With the connected-but-unfetched state gone:

- `person_spotify.artists_synced_at` is `NOT NULL DEFAULT NOW()`. The table already exists in prod, so `migrations.sql` gains idempotent `ALTER` statements, preceded by a `DELETE` of rows whose sync time is null: those are connects whose artist fetch failed, which under the new rule would never have been stored, and the affected users see the Connect button again. The staleness query loses its `IS NULL` branch and the upsert its nullable-artists handling.
- The own-profile payload loses `spotify_artists_synced`, and the only remaining empty state on the profile tab, a real account with no listening history, says so.
- The backfill test is replaced by one asserting a failed fetch stores nothing and returns the error.

The cron is unchanged: a failed refresh still keeps the old list and token, and bumps `attempted_at` for the retry backoff.

## Verification

- Backend `mypy.sh`, frontend `tsc --noEmit` and eslint: clean.
- The upsert, update, staleness and own-profile queries were executed against a scratch database built from `init-api.sql` + `migrations.sql` (applied twice): the payload no longer carries the synced flag, a stale row is picked up, and a failed refresh leaves the token in place and the row stale.
- The migration was applied twice to a scratch database built from `main`'s schema holding one null-sync row and one synced row: the null row is removed, the synced row survives, the column ends up `NOT NULL DEFAULT NOW()`, and an insert without the column succeeds.
- The functionality tests and the apex round trip in a browser are not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
