### PR TITLE
Spotify: return to the apex host when the flow started there

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -100,6 +100,7 @@ services:
       DUO_SPOTIFY_TOKEN_URL: http://spotifymock:3003/api/token
       DUO_SPOTIFY_API_URL: http://spotifymock:3003
       DUO_SPOTIFY_WEB_REDIRECT_URL: http://test-web.example/
+      DUO_SPOTIFY_APEX_REDIRECT_URL: http://test-apex.example/
       DUO_SPOTIFY_APP_REDIRECT_URL: http://test-app.example/
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       DUO_SPOTIFY_TOKEN_URL: http://spotifymock:3003/api/token
       DUO_SPOTIFY_API_URL: http://spotifymock:3003
       DUO_SPOTIFY_WEB_REDIRECT_URL: http://localhost:8081/profile
+      DUO_SPOTIFY_APEX_REDIRECT_URL: http://localhost:8081/profile
       DUO_SPOTIFY_APP_REDIRECT_URL: app.duolicious://spotify
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/backend/service/api/auth/spotify_oauth.py
+++ b/backend/service/api/auth/spotify_oauth.py
@@ -14,6 +14,7 @@ from serviceshared.spotify.sql import (
 )
 
 from serviceshared.duoenv.api import (
+    SPOTIFY_APEX_REDIRECT_URL,
     SPOTIFY_APP_REDIRECT_URL,
     SPOTIFY_AUTHORIZE_URL,
     SPOTIFY_REDIRECT_URI,
@@ -23,6 +24,7 @@ from serviceshared.duoenv.api import (
 
 _REDIRECT_TARGETS = {
     'web': SPOTIFY_WEB_REDIRECT_URL,
+    'apex': SPOTIFY_APEX_REDIRECT_URL,
     'app': SPOTIFY_APP_REDIRECT_URL,
 }
 

--- a/backend/service/api/duotypes/__init__.py
+++ b/backend/service/api/duotypes/__init__.py
@@ -704,7 +704,7 @@ class PostSearchFilterAnswer(BaseModel):
 
 
 class PostSpotifyAuthorize(BaseModel):
-    redirect_target: Literal['web', 'app']
+    redirect_target: Literal['web', 'apex', 'app']
 
 
 class PostJoinClub(BaseModel):

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -44,6 +44,10 @@ SPOTIFY_WEB_REDIRECT_URL = str_with(
     'DUO_SPOTIFY_WEB_REDIRECT_URL',
     'https://web.duolicious.app/profile',
 )
+SPOTIFY_APEX_REDIRECT_URL = str_with(
+    'DUO_SPOTIFY_APEX_REDIRECT_URL',
+    'https://duolicious.app/profile',
+)
 SPOTIFY_APP_REDIRECT_URL = str_with(
     'DUO_SPOTIFY_APP_REDIRECT_URL',
     'app.duolicious://spotify',

--- a/backend/test/functionality1/spotify.sh
+++ b/backend/test/functionality1/spotify.sh
@@ -280,6 +280,18 @@ failed_initial_fetch_backfills () {
   j_assert_length "$(jq '.spotify_artists' <<< "$profile")" 10
 }
 
+apex_returns_to_the_apex_host () {
+  echo 'A flow started on the apex host returns to the apex host'
+
+  setup
+
+  mint_state apex
+
+  local location=$(callback_location "code=mock-code&state=$state")
+
+  [[ "$location" == 'http://test-apex.example/?spotify=connected' ]]
+}
+
 revocation_clears_tokens_and_artists () {
   echo 'Revoking authorization at Spotify clears tokens and artists'
 
@@ -322,5 +334,6 @@ user_denial_redirects_with_error
 disconnect_empties_everything
 cron_refreshes_artists
 failed_initial_fetch_backfills
+apex_returns_to_the_apex_host
 revocation_clears_tokens_and_artists
 deleting_account_cascades

--- a/frontend/api/oauth-return.tsx
+++ b/frontend/api/oauth-return.tsx
@@ -46,6 +46,9 @@ const navigateAway = (url: string): Promise<void> =>
     window.location.assign(url);
   });
 
+const webReturnTarget = (): 'web' | 'apex' =>
+  window.location.hostname === 'duolicious.app' ? 'apex' : 'web';
+
 const parseQueryParams = (url: string): URLSearchParams => {
   // Some browsers/env may not populate URL.searchParams from a relative-ish
   // string; parse the query manually as a fallback.
@@ -62,4 +65,5 @@ export {
   navigateAway,
   parseQueryParams,
   takeWebReturnParams,
+  webReturnTarget,
 };

--- a/frontend/api/social-auth.tsx
+++ b/frontend/api/social-auth.tsx
@@ -10,6 +10,7 @@ import {
   navigateAway,
   parseQueryParams,
   takeWebReturnParams,
+  webReturnTarget,
 } from './oauth-return';
 import {
   APPLE_ANDROID_RETURN_URL,
@@ -375,9 +376,7 @@ const signInWithAppleWeb = async (
   // backend's callback must 302 back to the origin the flow started on —
   // the nonce lives in this origin's sessionStorage — so the state names
   // which entry of the backend's redirect allow-list to use.
-  const target =
-    window.location.hostname === 'duolicious.app' ? 'apex' : 'web';
-  const state = `${nonce}.${target}`;
+  const state = `${nonce}.${webReturnTarget()}`;
 
   const authUrl = _buildAppleAuthorizeUrl({
     clientId: APPLE_WEB_CLIENT_ID,

--- a/frontend/api/spotify.tsx
+++ b/frontend/api/spotify.tsx
@@ -5,6 +5,7 @@ import {
   navigateAway,
   parseQueryParams,
   takeWebReturnParams,
+  webReturnTarget,
 } from './oauth-return';
 import { notify } from '../events/events';
 import { DefaultText } from '../components/default-text';
@@ -56,7 +57,7 @@ const connectSpotify = async (): Promise<void> => {
   const response = await japi<PostSpotifyAuthorizeResponse>(
     'post',
     '/spotify/authorize',
-    { redirect_target: Platform.OS === 'web' ? 'web' : 'app' },
+    { redirect_target: Platform.OS === 'web' ? webReturnTarget() : 'app' },
   );
 
   if (!response.ok || !response.json) {


### PR DESCRIPTION
The SPA is served on both `web.duolicious.app` and `duolicious.app`, but the Spotify callback only knew one web return target, so connecting from the apex host dropped the user on the web host. This adds a third target, `apex`, mirroring the Apple callback:

- `DUO_SPOTIFY_APEX_REDIRECT_URL`, defaulting to `https://duolicious.app/profile`, and `apex` in the callback's allow-list and in `PostSpotifyAuthorize.redirect_target`.
- The web client picks `web` or `apex` by hostname through a new `webReturnTarget()` in `api/oauth-return.tsx`, which the Apple web flow now uses too instead of its own inline check.
- Dev and test compose files set the new variable, and `spotify.sh` gains a test for the apex round trip.

No change to what happens when the artist fetch fails during connect: the token is still stored and the cron backfills.

Backend `mypy.sh`, frontend `tsc --noEmit` and eslint are clean. The functionality tests and a browser round trip from the apex host are not run here.

Replaces #1570, which bundled this with a fail-fast change that is no longer wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
