### PR TITLE
Landing banner: show the members-only copy without cycling to the member count

### DIFF
--- a/frontend/components/cross-fade.tsx
+++ b/frontend/components/cross-fade.tsx
@@ -4,7 +4,6 @@ import Animated, {
   SharedValue,
   useAnimatedStyle,
   useSharedValue,
-  withDelay,
   withTiming,
 } from 'react-native-reanimated';
 
@@ -36,40 +35,6 @@ const FadeLayers = ({ progress, front, back, style }: FadeLayersProps) => {
         </Animated.View>
       }
     </View>
-  );
-};
-
-type CrossFadeProps = {
-  showFront: boolean
-  front: ReactNode
-  back: ReactNode
-  minBackMs?: number
-  duration?: number
-  style?: StyleProp<ViewStyle>
-};
-
-const CrossFade = ({
-  showFront,
-  front,
-  back,
-  minBackMs = 0,
-  duration = 500,
-  style,
-}: CrossFadeProps) => {
-  const progress = useSharedValue(0);
-  const mountedAt = useRef(Date.now());
-
-  useEffect(() => {
-    const remaining = Math.max(0, minBackMs - (Date.now() - mountedAt.current));
-
-    progress.value = withDelay(
-      remaining,
-      withTiming(showFront ? 1 : 0, { duration })
-    );
-  }, [showFront]);
-
-  return (
-    <FadeLayers progress={progress} front={front} back={back} style={style} />
   );
 };
 
@@ -152,6 +117,5 @@ const CrossFadeText = ({
 };
 
 export {
-  CrossFade,
   CrossFadeText,
 };

--- a/frontend/components/sign-up-banner.tsx
+++ b/frontend/components/sign-up-banner.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Pressable, View, useWindowDimensions } from 'react-native';
-import { CrossFade, CrossFadeText } from './cross-fade';
+import { CrossFadeText } from './cross-fade';
 import { DefaultText } from './default-text';
-import { Logo16 } from './logo';
 import { isMobile } from '../util/util';
 import { useAppTheme } from '../app-theme/app-theme';
 import { showSignUp } from './modal/sign-up-modal';
-import { useNumActiveUsers } from './welcome-screen';
 import { useBannerProspectName } from '../events/banner-prospect-name';
 import { useSignUpBanner } from '../events/sign-up-banner';
 import { COLUMN_MAX_WIDTH } from '../constants/constants';
@@ -23,21 +21,11 @@ const SignUpBannerCard = ({ prospectHandle, overContentColumn }: {
 }) => {
   const { appTheme } = useAppTheme();
   const { width: windowWidth } = useWindowDimensions();
-  const numActiveUsers = useNumActiveUsers(undefined);
   const prospectName = useBannerProspectName(prospectHandle);
-  const [showNumActiveUsers, setShowNumActiveUsers] = useState(false);
   const [cardWidth, setCardWidth] = useState<number>();
 
   const isNarrow =
     (cardWidth ?? Math.min(windowWidth, COLUMN_MAX_WIDTH)) < 400;
-
-  useEffect(() => {
-    const interval = setInterval(
-      () => setShowNumActiveUsers((s) => !s),
-      5000
-    );
-    return () => clearInterval(interval);
-  }, []);
 
   // Longer names blow out the button's width, so fall back to the default copy.
   const label = prospectName && prospectName.length <= 7
@@ -99,44 +87,18 @@ const SignUpBannerCard = ({ prospectHandle, overContentColumn }: {
             gap: 14,
           }}
         >
-          <CrossFade
-            style={{ flex: 1 }}
-            showFront={showNumActiveUsers && numActiveUsers !== undefined}
-            minBackMs={5000}
-            front={
-              <View
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 12,
-                }}
-              >
-                <Logo16 size={64} color={appTheme.brandColor} rectSize={0.3} />
-                <View style={{ flexShrink: 1 }}>
-                  <DefaultText style={{ fontWeight: '900', fontSize: 20 }}>
-                    {numActiveUsers === undefined ? '\xa0' : numActiveUsers.toLocaleString()}
-                  </DefaultText>
-                  <DefaultText style={{ fontWeight: '600', fontSize: 14 }}>
-                    Active Members
-                  </DefaultText>
-                </View>
-              </View>
-            }
-            back={
-              <DefaultText
-                style={{
-                  fontWeight: '900',
-                  fontSize: isNarrow ? 14 : 18,
-                  lineHeight: isNarrow ? 22 : undefined,
-                  textAlign: 'center',
-                  textWrap: 'balance',
-                }}
-              >
-                {'See members-only profiles by joining'}
-              </DefaultText>
-            }
-          />
+          <DefaultText
+            style={{
+              flex: 1,
+              fontWeight: '900',
+              fontSize: isNarrow ? 14 : 18,
+              lineHeight: isNarrow ? 22 : undefined,
+              textAlign: 'center',
+              textWrap: 'balance',
+            }}
+          >
+            {'See members-only profiles by joining'}
+          </DefaultText>
           <View style={{ flex: 1 }}>
             <Pressable
               onPress={() => showSignUp(true, signUpMessage)}


### PR DESCRIPTION
The sign-up banner on the landing page alternated every five seconds between the active member count and "See members-only profiles by joining". This shows only the latter, with the same typography and sizing it had as the banner's back face, and with no transition.

Removed along with it:

- the five-second toggle and its state in `sign-up-banner.tsx`, and the banner's use of `useNumActiveUsers` (the welcome screen still uses that hook);
- the two-face `CrossFade` component in `cross-fade.tsx`, which the banner was the only user of. `CrossFadeText`, which still animates the button label between "Join or sign in" and "Message <name>", is untouched.

`tsc --noEmit`, eslint and Jest pass. Not viewed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
