### PR TITLE
Prospect profile: refetch when the viewer signs in or out

### DIFF
--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -984,7 +984,7 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
         });
       }
     })();
-  }, [handle]);
+  }, [handle, signedInUser?.personUuid]);
 
   const photoUuid = data === undefined ?
     undefined :


### PR DESCRIPTION
## Problem

Open a members-only profile on web while logged out then sign in from the "Join or sign in" banner. The app shows "Profile not found" until the browser page is manually refreshed.

## Cause

The profile fetch effect only re-ran when the URL handle changed. Signing in from the profile keeps the screen mounted, so the anonymous 404 stayed in `notFound` state. The "Sign in to view this profile" copy is keyed on there being no signed-in user, so once signed in the same stale 404 was relabelled "Profile not found".

## Fix

Re-key the fetch on the viewer's identity (`signedInUser?.personUuid`) so a login or logout refetches the profile with the current session. The session token is persisted before the signed-in user is broadcast, so the refetch is authenticated.

## Verification

Drove the real web app through the email sign-in flow with Playwright against a mock API that 404s the profile anonymously and returns it with a bearer token.

- With the fix: after the OTP, the app re-requested the profile with the token and rendered it on the same URL, no refresh.
- Without the fix: the same flow ended on "Profile not found" with no authenticated request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
