### PR TITLE
End the distance-sort A/B test and trial a 1000-candidate distance target

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -43,8 +43,6 @@ services:
     environment:
       DUO_ENV: dev
 
-      DUO_DISTANCE_SORT_TRIAL: 'false'
-
       # Unit-test discovery runs in this container and imports
       # service.cron, which fails fast without this or an OpenAI key.
       DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION: 'A friendly description for this club.'

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -43,6 +43,8 @@ services:
     environment:
       DUO_ENV: dev
 
+      DUO_CANDIDATE_TARGET_TRIAL: 'false'
+
       # Unit-test discovery runs in this container and imports
       # service.cron, which fails fast without this or an OpenAI key.
       DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION: 'A friendly description for this club.'

--- a/backend/service/api/person/__init__.py
+++ b/backend/service/api/person/__init__.py
@@ -10,14 +10,13 @@ from serviceshared.database._row import row_int_or_none
 from collections.abc import Mapping, Sequence
 from typing import Tuple
 from serviceshared.util.coerce import string
-from service.api.person.bestage import AgeBounds, best_age
+from service.api.person.bestage import best_age
 from service.api.person.bestdistance import (
     CANDIDATE_LIMIT,
     best_distance,
     distance_preference,
 )
 from service.api.person.urlslug import reserve_onboardee_url_slug
-from service.api.search.sql.search import SORT_DISTANCE, SORT_MATCH_PERCENTAGE
 import service.api.duotypes as t
 import json
 import secrets
@@ -68,10 +67,7 @@ from serviceshared.verification.messages import (
 )
 
 
-from serviceshared.duoenv.api import (
-    DISTANCE_SORT_TRIAL,
-    ENV as DUO_ENV,
-)
+from serviceshared.duoenv.api import ENV as DUO_ENV
 from serviceshared.duoenv.shared import R2_ACCT_ID
 
 logger = logging.getLogger(__name__)
@@ -145,11 +141,13 @@ def _otp_from_rows(rows: Sequence[Mapping[str, object]]) -> str | None:
     except:
         return None
 
-async def _best_distance(
-    tx: Tx,
-    person_id: int,
-    bounds: AgeBounds,
-) -> float | None:
+async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
+    age = row_int(
+        await tx.require_one(Q_PERSON_AGE, params=dict(person_id=person_id)),
+        'age',
+    )
+    bounds = best_age(age)
+
     async def count_within(distance_km: float) -> int:
         counted = await tx.require_one(Q_COUNT_NEARBY_CANDIDATES, params=dict(
             person_id=person_id,
@@ -167,26 +165,11 @@ async def _best_distance(
         'is_joining_club',
     )
 
-    return distance_preference(candidates, is_joining_club=is_joining_club)
-
-
-async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
-    age = row_int(
-        await tx.require_one(Q_PERSON_AGE, params=dict(person_id=person_id)),
-        'age',
-    )
-    bounds = best_age(age)
-
-    # The 50-50 split keys on `person.id` parity so the arm stays
-    # recoverable from the id alone after the user changes their filters.
-    trial = DISTANCE_SORT_TRIAL and person_id % 2 == 0
-
     await tx.execute(Q_UPDATE_BEST_SEARCH_PREFERENCES, params=dict(
         person_id=person_id,
         min_age=bounds.min_age,
         max_age=bounds.max_age,
-        distance=None if trial else await _best_distance(tx, person_id, bounds),
-        sort_by=SORT_DISTANCE if trial else SORT_MATCH_PERCENTAGE,
+        distance=distance_preference(candidates, is_joining_club=is_joining_club),
     ))
 
 

--- a/backend/service/api/person/__init__.py
+++ b/backend/service/api/person/__init__.py
@@ -11,11 +11,7 @@ from collections.abc import Mapping, Sequence
 from typing import Tuple
 from serviceshared.util.coerce import string
 from service.api.person.bestage import best_age
-from service.api.person.bestdistance import (
-    CANDIDATE_LIMIT,
-    best_distance,
-    distance_preference,
-)
+from service.api.person.bestdistance import best_distance, distance_preference
 from service.api.person.urlslug import reserve_onboardee_url_slug
 import service.api.duotypes as t
 import json
@@ -67,7 +63,10 @@ from serviceshared.verification.messages import (
 )
 
 
-from serviceshared.duoenv.api import ENV as DUO_ENV
+from serviceshared.duoenv.api import (
+    CANDIDATE_TARGET_TRIAL,
+    ENV as DUO_ENV,
+)
 from serviceshared.duoenv.shared import R2_ACCT_ID
 
 logger = logging.getLogger(__name__)
@@ -148,17 +147,20 @@ async def _update_best_search_preferences(tx: Tx, person_id: int) -> None:
     )
     bounds = best_age(age)
 
+    trial = CANDIDATE_TARGET_TRIAL and person_id % 2 == 0
+    target_candidates = 1000 if trial else 2000
+
     async def count_within(distance_km: float) -> int:
         counted = await tx.require_one(Q_COUNT_NEARBY_CANDIDATES, params=dict(
             person_id=person_id,
             distance_metres=distance_km * 1000,
             min_age=0 if bounds.min_age is None else bounds.min_age,
             max_age=999 if bounds.max_age is None else bounds.max_age,
-            candidate_limit=CANDIDATE_LIMIT,
+            candidate_limit=target_candidates * 2,
         ))
         return row_int(counted, 'candidates')
 
-    candidates = await best_distance(count_within)
+    candidates = await best_distance(count_within, target_candidates)
 
     is_joining_club = row_bool(
         await tx.require_one(Q_IS_JOINING_CLUB, params=dict(person_id=person_id)),

--- a/backend/service/api/person/bestdistance/__init__.py
+++ b/backend/service/api/person/bestdistance/__init__.py
@@ -1,9 +1,6 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
-TARGET_CANDIDATES = 2000
-CANDIDATE_LIMIT = TARGET_CANDIDATES * 2
-
 _ITERATIONS = 5
 _SEARCH_CEILING_KM = 10000.0
 _UNREACHABLE_CANDIDATES = 10 ** 9
@@ -19,6 +16,7 @@ class Candidates:
 
 async def best_distance(
     count_within: Callable[[float], Awaitable[int]],
+    target_candidates: int,
 ) -> Candidates:
     points = [
         Candidates(0.0, 0),
@@ -29,7 +27,7 @@ async def best_distance(
     for _ in range(_ITERATIONS):
         nearest = sorted(
             points,
-            key=lambda p: (abs(p.count - TARGET_CANDIDATES), p.distance_km),
+            key=lambda p: (abs(p.count - target_candidates), p.distance_km),
         )[:2]
 
         distance_km = sum(p.distance_km for p in nearest) / 2

--- a/backend/service/api/person/sql/__init__.py
+++ b/backend/service/api/person/sql/__init__.py
@@ -5,6 +5,7 @@ from serviceshared.constants import (
     MAX_RELATED_CLUBS,
     MIN_CLUB_PAGE_MEMBERS,
 )
+from service.api.search.sql.search import SORT_MATCH_PERCENTAGE
 from serviceshared.commonsql import (
     PHOTO_GEOMETRY,
     Q_COMPUTED_FLAIR,
@@ -389,8 +390,7 @@ UPDATE
 SET
     min_age = %(min_age)s,
     max_age = %(max_age)s,
-    distance = %(distance)s::NUMERIC::SMALLINT,
-    sort_by_id = (SELECT id FROM sort_by WHERE name = %(sort_by)s)
+    distance = %(distance)s::NUMERIC::SMALLINT
 WHERE
     person_id = %(person_id)s
 """
@@ -491,6 +491,7 @@ WITH onboardee_location AS (
         religion_ids,
         star_sign_ids,
         last_online_id,
+        sort_by_id,
         show_messaged,
         show_skipped
     )
@@ -518,6 +519,7 @@ WITH onboardee_location AS (
         ARRAY(SELECT id FROM religion ORDER BY id),
         ARRAY(SELECT id FROM star_sign ORDER BY id),
         (SELECT id FROM last_online WHERE name = '{LAST_ONLINE_DEFAULT_NAME}'),
+        (SELECT id from sort_by where name = '{SORT_MATCH_PERCENTAGE}'),
         TRUE,
         FALSE
     FROM new_person

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -1,6 +1,5 @@
 from serviceshared.duoenv.read import (
     csv,
-    flag_with,
     float_with,
     int_with,
     required_str,
@@ -55,5 +54,3 @@ SPOTIFY_APP_REDIRECT_URL = str_with(
 
 VAPID_SUBJECT = str_with('DUO_VAPID_SUBJECT', 'mailto:support@duolicious.app')
 VAPID_PRIVATE_KEY = str_with('DUO_VAPID_PRIVATE_KEY', '')
-
-DISTANCE_SORT_TRIAL = flag_with('DUO_DISTANCE_SORT_TRIAL', 'true')

--- a/backend/serviceshared/duoenv/api.py
+++ b/backend/serviceshared/duoenv/api.py
@@ -1,5 +1,6 @@
 from serviceshared.duoenv.read import (
     csv,
+    flag_with,
     float_with,
     int_with,
     required_str,
@@ -54,3 +55,5 @@ SPOTIFY_APP_REDIRECT_URL = str_with(
 
 VAPID_SUBJECT = str_with('DUO_VAPID_SUBJECT', 'mailto:support@duolicious.app')
 VAPID_PRIVATE_KEY = str_with('DUO_VAPID_PRIVATE_KEY', '')
+
+CANDIDATE_TARGET_TRIAL = flag_with('DUO_CANDIDATE_TARGET_TRIAL', 'true')


### PR DESCRIPTION
Two commits, meant to be read separately.

## 1. End the distance-sort A/B test in favour of the original defaults

Reverts #1569. After 1,041 sign-ups the "Distance" arm retained about 4 points fewer users than the control (68% vs 72%, roughly 77% odds of being genuinely worse), so every new user goes back to the "Match percentage" sort with the solved distance. Nothing structural is kept from that PR.

## 2. Trial a 1000-candidate distance target for half of new users

The onboarding distance solver bisects for the radius that encloses a target number of candidates. That target is 2000 for everyone today. New users with an even `person.id` now get a target of 1000, so their default "Furthest distance" is tighter; odd ids keep 2000. The count query's cap stays at twice the target so the bisection can still tell "over target" from "at target".

`DUO_CANDIDATE_TARGET_TRIAL` turns the arm on and defaults to on; the test compose file pins it off so the functional suite sees the control arm.

### Worth knowing

- The split keys on id parity like the previous trials, so cohorts must again be separated by sign-up date at analysis time.
- The 500-candidate floor that drops the distance limit entirely, and the 8000 km ceiling, are unchanged in both arms.
- In areas with fewer than about 1000 reachable candidates both arms push the radius outward and land in roughly the same place, so the trial mostly bites in dense cities.

## Verification

- `mypy.sh` passes over all 236 source files.
- Relying on CI for the functional suite; it runs the control arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
