### PR TITLE
Run pull request checks whatever the base branch

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -8,8 +8,6 @@ on:
       - backend/**
       - .github/workflows/backend-test.yml
   pull_request:
-    branches:
-      - main
     paths:
       - backend/**
       - .github/workflows/backend-test.yml

--- a/.github/workflows/frontend-eslint.yml
+++ b/.github/workflows/frontend-eslint.yml
@@ -7,8 +7,6 @@ on:
       - frontend/**
       - .github/workflows/frontend-eslint.yml
   pull_request:
-    branches:
-      - main
     paths:
       - frontend/**
       - .github/workflows/frontend-eslint.yml

--- a/.github/workflows/frontend-jest.yml
+++ b/.github/workflows/frontend-jest.yml
@@ -7,8 +7,6 @@ on:
       - frontend/**
       - .github/workflows/frontend-jest.yml
   pull_request:
-    branches:
-      - main
     paths:
       - frontend/**
       - .github/workflows/frontend-jest.yml

--- a/.github/workflows/frontend-playwright.yml
+++ b/.github/workflows/frontend-playwright.yml
@@ -7,8 +7,6 @@ on:
       - frontend/**
       - .github/workflows/frontend-playwright.yml
   pull_request:
-    branches:
-      - main
     paths:
       - frontend/**
       - .github/workflows/frontend-playwright.yml

--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -7,8 +7,6 @@ on:
       - frontend/**
       - .github/workflows/frontend-publish.yml
   pull_request:
-    branches:
-      - main
     paths:
       - frontend/**
       - .github/workflows/frontend-publish.yml

--- a/.github/workflows/frontend-type-checks.yml
+++ b/.github/workflows/frontend-type-checks.yml
@@ -7,8 +7,6 @@ on:
       - frontend/**
       - .github/workflows/frontend-type-checks.yml
   pull_request:
-    branches:
-      - main
     paths:
       - frontend/**
       - .github/workflows/frontend-type-checks.yml


### PR DESCRIPTION
The test, lint and publish workflows only fired for pull requests against `main`, so a PR stacked on another branch (like #1580 on #1582) got no checks at all. This drops the `branches: main` filter from every `pull_request` trigger; pushes keep the `main`-only filter.

`Frontend Publish` also runs on `pull_request`, so stacked PRs now get a preview deploy too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
